### PR TITLE
WIP Make default executable Platform independen

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -128,10 +128,7 @@ mod tests {
         use crate::logging;
 
         fn try_out_browser() -> Result<(), Error> {
-            let browser = Browser::new(LaunchOptions {
-                headless: true,
-                ..Default::default()
-            })?;
+            let browser = Browser::new(LaunchOptions::default().unwrap().headless(true))?;
 
             let method = GetTargets {};
             let _targets = browser.call_method(method)?.target_infos;
@@ -148,11 +145,7 @@ mod tests {
     fn ctrlc_chrome() {
         use crate::logging;
         logging::enable_logging();
-        let _browser = Browser::new(LaunchOptions {
-            headless: false,
-            ..Default::default()
-        })
-        .unwrap();
+        let _browser = Browser::new(LaunchOptions::default().unwrap().headless(false)).unwrap();
         std::thread::sleep(time::Duration::from_secs(40));
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -27,7 +27,9 @@ enum ChromeLaunchError {
     NoAvailablePorts,
     #[fail(display = "The chosen debugging port is already in use")]
     DebugPortInUse,
-    #[fail(display = "No applicable default launch options, most likely the chrome executable was not found")]
+    #[fail(
+        display = "No applicable default launch options, most likely the chrome executable was not found"
+    )]
     NoDefaultLaunchOptions,
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -27,6 +27,8 @@ enum ChromeLaunchError {
     NoAvailablePorts,
     #[fail(display = "The chosen debugging port is already in use")]
     DebugPortInUse,
+    #[fail(display = "No applicable default launch options, most likely the chrome executable was not found")]
+    NoDefaultLaunchOptions,
 }
 
 struct TemporaryProcess(Child);
@@ -95,9 +97,18 @@ impl LaunchOptions {
         self.port = port;
         self
     }
+
+    pub fn path(mut self, path: std::path::PathBuf) -> Self {
+        self.path = path;
+        self
+    }
 }
 
 impl Process {
+    pub fn default() -> Result<Self, Error> {
+        Self::new(LaunchOptions::default().ok_or(ChromeLaunchError::NoDefaultLaunchOptions)?)
+    }
+
     pub fn new(launch_options: LaunchOptions) -> Result<Self, Error> {
         info!("Trying to start Chrome");
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -39,19 +39,61 @@ impl Drop for TemporaryProcess {
     }
 }
 
-pub struct LaunchOptions<'a> {
+pub struct LaunchOptions {
     pub headless: bool,
     pub port: Option<u16>,
-    pub path: &'a str,
+    pub path: std::path::PathBuf,
 }
 
-impl<'a> Default for LaunchOptions<'a> {
-    fn default() -> Self {
-        LaunchOptions {
+impl LaunchOptions {
+    pub fn default_executable() -> Option<std::path::PathBuf> {
+        // TODO BSDs/Unixes are the same?
+        #[cfg(target_os = "linux")]
+        {
+            // TODO Look at $BROWSER and if it points to a chrome binary
+            // $BROWSER may also provide default arguments, which we may
+            // or may not override later on.
+
+            // TODO More paths!?
+            let default_paths = &["/usr/bin/google-chrome-stable"][..];
+            for path in default_paths {
+                if std::path::Path::new(path).exists() {
+                    return Some(path.into());
+                }
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let default_paths =
+                &["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"][..];
+            for path in default_paths {
+                if std::path::Path::new(path).exists() {
+                    return Some(path.into());
+                }
+            }
+        }
+        // TODO Windows
+        // Check HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe
+        None
+    }
+
+    pub fn default() -> Option<Self> {
+        Some(LaunchOptions {
             headless: true,
             port: None,
-            path: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-        }
+            path: Self::default_executable()?,
+        })
+    }
+
+    pub fn headless(mut self, headless: bool) -> Self {
+        self.headless = headless;
+        self
+    }
+
+    pub fn port(mut self, port: Option<u16>) -> Self {
+        self.port = port;
+        self
     }
 }
 
@@ -127,7 +169,7 @@ impl Process {
         }
 
         let process = TemporaryProcess(
-            Command::new(launch_options.path)
+            Command::new(&launch_options.path)
                 .args(&args)
                 .stderr(Stdio::piped())
                 .spawn()?,
@@ -195,6 +237,7 @@ fn port_is_available(port: u16) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::fs::File;
     use std::io::prelude::*;
     use std::thread;
@@ -220,7 +263,7 @@ mod tests {
     fn kills_process_on_drop() {
         env_logger::try_init().unwrap_or(());
         {
-            let _chrome = &mut super::Process::new(Default::default()).unwrap();
+            let _chrome = &mut super::Process::new(LaunchOptions::default().unwrap()).unwrap();
         }
 
         let child_pids = current_child_pids();
@@ -237,11 +280,7 @@ mod tests {
             let handle = thread::spawn(|| {
                 // these sleeps are to make it more likely the chrome startups will overlap
                 std::thread::sleep(std::time::Duration::from_millis(10));
-                let chrome = super::Process::new(super::LaunchOptions {
-                    port: None,
-                    ..Default::default()
-                })
-                .unwrap();
+                let chrome = super::Process::new(super::LaunchOptions::default().unwrap()).unwrap();
                 std::thread::sleep(std::time::Duration::from_millis(100));
                 chrome.debug_ws_url.clone()
             });
@@ -260,11 +299,9 @@ mod tests {
         let mut handles = Vec::new();
 
         for _ in 0..10 {
-            let chrome = super::Process::new(super::LaunchOptions {
-                headless: false,
-                ..Default::default()
-            })
-            .unwrap();
+            let chrome =
+                super::Process::new(super::LaunchOptions::default().unwrap().headless(false))
+                    .unwrap();
             handles.push(chrome);
         }
     }

--- a/src/web_socket_connection.rs
+++ b/src/web_socket_connection.rs
@@ -91,7 +91,9 @@ mod tests {
     #[test]
     fn you_can_send_messages() {
         logging::enable_logging();
-        let chrome = crate::browser::Browser::new(Default::default()).unwrap();
+        let chrome =
+            crate::browser::Browser::new(crate::process::LaunchOptions::default().unwrap())
+                .unwrap();
 
         let (messages_tx, _messages_rx) = mpsc::channel::<crate::cdtp::Message>();
 


### PR DESCRIPTION
Here is some code to make the default executable discoverable on multiple platforms. It allows to execute all tests on Linux, which pass (besides the integration tests, which have to go anyway).

`LaunchOptions` inevitably loses the ability to implement `Default`, because we may not be able to (somewhat) safely discover a default path. It is up to the user (and highly platform dependent) what to do then.
