### PR TITLE
WIP: Add groundwork for integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ which = "2.0.1"
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6"
 
+[dev-dependencies]
+tiny_http = "0.6"
+
 [lib]
 name = "headless_chrome"
 path = "src/lib.rs"

--- a/tests/form.html
+++ b/tests/form.html
@@ -1,0 +1,23 @@
+<html>
+    <body>
+    <script>
+        function launch() {
+            var target = document.getElementById("target");
+            var sneak = document.getElementById("sneakattack");
+            var proto = document.createElement("div");
+            if (sneak.checked) {
+                proto.innerText = "Comrades, have a nice day!";
+            } else {
+                proto.innerText = "Missiles launched against " + target.value;
+            }
+            document.getElementById("protocol").appendChild(proto);
+        }
+    </script>
+        <form id="control">
+            <input type="text" id="target">
+            <input type="checkbox" id="sneakattack">
+            <button type="button" onClick="launch()">Launch the missiles!</button>
+        </form>
+        <div id="protocol"></div>
+    </body>
+</html>

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,0 +1,71 @@
+use std::io;
+use std::sync::{atomic, Arc};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+pub struct Server {
+    server: Arc<tiny_http::Server>,
+    handler: Option<JoinHandle<Result<(), io::Error>>>,
+    shall_exit: Arc<atomic::AtomicBool>,
+}
+
+impl Server {
+    pub fn new(
+        responder: impl Fn(tiny_http::Request) -> Result<(), io::Error> + Send + 'static,
+    ) -> Self {
+        let server = Arc::new(tiny_http::Server::http("127.0.0.1:0").unwrap());
+        let shall_exit = Arc::new(atomic::AtomicBool::new(false));
+        let srv = server.clone();
+        let exit = shall_exit.clone();
+        let handler = std::thread::spawn(move || {
+            loop {
+                if let Some(r) = srv.recv_timeout(Duration::from_millis(100))? {
+                    responder(r)?;
+                }
+                if exit.load(atomic::Ordering::Relaxed) {
+                    break;
+                }
+            }
+            Ok(())
+        });
+        Server {
+            server,
+            handler: Some(handler),
+            shall_exit,
+        }
+    }
+
+    pub fn with_dumb_html(data: &'static str) -> Self {
+        let responder = move |r: tiny_http::Request| {
+            let response = tiny_http::Response::new(
+                200.into(),
+                vec![
+                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html"[..]).unwrap(),
+                ],
+                io::Cursor::new(data),
+                Some(data.len()),
+                None,
+            );
+            r.respond(response)
+        };
+        Self::new(responder)
+    }
+
+    pub fn port(&self) -> u16 {
+        self.server.server_addr().port()
+    }
+
+    pub fn exit(&mut self) -> Result<(), io::Error> {
+        self.shall_exit.store(true, atomic::Ordering::Relaxed);
+        match self.handler.take() {
+            Some(h) => h.join().unwrap(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.exit().unwrap()
+    }
+}

--- a/tests/simple.html
+++ b/tests/simple.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        <div id="foobar">Foobar</div>
+    </body>
+</html>

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,0 +1,47 @@
+use headless_chrome::{browser, logging, process, tab};
+use std::sync::Arc;
+mod server;
+
+/// Launches a dumb server that unconditionally serves the given data as a
+/// successful html response; launches a new browser and navigates to the
+/// server.
+///
+/// Users must hold on to the server, which stops when dropped.
+fn dumb_server(data: &'static str) -> (server::Server, browser::Browser, Arc<tab::Tab>) {
+    let server = server::Server::with_dumb_html(data);
+    let browser = browser::Browser::new(process::LaunchOptions::default().unwrap()).unwrap();
+    let tab = browser.wait_for_initial_tab().unwrap();
+    tab.navigate_to(&format!("http://127.0.0.1:{}", server.port()))
+        .unwrap();
+    (server, browser, tab)
+}
+
+#[test]
+fn simple() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let (_server, _browser, tab) = dumb_server(include_str!("simple.html"));
+    tab.wait_for_element("div#foobar")?;
+    Ok(())
+}
+
+#[test]
+fn form_interaction() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let (_server, _browser, tab) = dumb_server(include_str!("form.html"));
+    tab.wait_for_element("input#target")?
+        .type_into("mothership")?;
+    tab.wait_for_element("button")?.click()?;
+    let d = tab.wait_for_element("div#protocol")?.get_description()?;
+    assert_eq!(
+        d.children.unwrap()[0].children.as_ref().unwrap()[0].node_value,
+        "Missiles launched against mothership"
+    );
+    tab.wait_for_element("input#sneakattack")?.click()?;
+    tab.wait_for_element("button")?.click()?;
+    let d = tab.wait_for_element("div#protocol")?.get_description()?;
+    assert_eq!(
+        d.children.unwrap()[1].children.as_ref().unwrap()[0].node_value,
+        "Comrades, have a nice day!"
+    );
+    Ok(())
+}


### PR DESCRIPTION
This adds some basic code to re-add integration tests: We use `tiny_http` to launch a simple http-server and serve static html from there. Tests can easily serve html content and do their worst about it.

Needs expansion.