### PR TITLE
Add Node::find

### DIFF
--- a/src/cdtp/dom.rs
+++ b/src/cdtp/dom.rs
@@ -16,6 +16,41 @@ pub struct Node {
     pub attributes: Option<NodeAttributes>,
 }
 
+impl Node {
+    /// Returns the first node for which the given closure returns true.
+    ///
+    /// Nodes are inspected breadth-first down their children.
+    pub fn find<F: FnMut(&Self) -> bool>(&self, predicate: F) -> Option<&Self> {
+        let mut s = SearchVisitor::new(predicate);
+        s.visit(self);
+        s.item
+    }
+}
+
+struct SearchVisitor<'a, F> {
+    predicate: F,
+    item: Option<&'a Node>,
+}
+
+impl<'a, F: FnMut(&Node) -> bool> SearchVisitor<'a, F> {
+    fn new(predicate: F) -> Self {
+        SearchVisitor {
+            predicate,
+            item: None,
+        }
+    }
+
+    fn visit(&mut self, n: &'a Node) {
+        if (self.predicate)(n) {
+            self.item = Some(n);
+        } else if self.item.is_none() {
+            if let Some(c) = &n.children {
+                c.iter().for_each(|n| self.visit(n))
+            }
+        }
+    }
+}
+
 pub mod methods {
     use crate::cdtp::Method;
     use serde::{Deserialize, Serialize};

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -32,16 +32,14 @@ fn form_interaction() -> Result<(), failure::Error> {
         .type_into("mothership")?;
     tab.wait_for_element("button")?.click()?;
     let d = tab.wait_for_element("div#protocol")?.get_description()?;
-    assert_eq!(
-        d.children.unwrap()[0].children.as_ref().unwrap()[0].node_value,
-        "Missiles launched against mothership"
-    );
+    assert!(d
+        .find(|n| n.node_value == "Missiles launched against mothership")
+        .is_some());
     tab.wait_for_element("input#sneakattack")?.click()?;
     tab.wait_for_element("button")?.click()?;
     let d = tab.wait_for_element("div#protocol")?.get_description()?;
-    assert_eq!(
-        d.children.unwrap()[1].children.as_ref().unwrap()[0].node_value,
-        "Comrades, have a nice day!"
-    );
+    assert!(d
+        .find(|n| n.node_value == "Comrades, have a nice day!")
+        .is_some());
     Ok(())
 }


### PR DESCRIPTION
This adds a little comfort to handling `Node`