### PR TITLE
Allow README to be doc-tested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ tiny_http = "0.6"
 [lib]
 name = "headless_chrome"
 path = "src/lib.rs"
+
+[features]
+nightly = []

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 [Puppeteer](https://github.com/GoogleChrome/puppeteer) for Rust. It looks a little something like this:
 
 ```rust
-use headless_chrome::{process, browser::{Browser, LaunchOptions}};
+use headless_chrome::browser::{Browser, LaunchOptions};
 
 fn browse_wikipedia() -> Result<(), failure::Error> {
-    let options = process::LaunchOptions::default().expect("Failed to find chrome");
+    let options = LaunchOptions::default().expect("Failed to find chrome");
     let browser = Browser::new(options)?;
 
     let tab = browser.wait_for_initial_tab()?;

--- a/README.md
+++ b/README.md
@@ -6,29 +6,30 @@
 [Puppeteer](https://github.com/GoogleChrome/puppeteer) for Rust. It looks a little something like this:
 
 ```rust
-use headless_chrome::browser::{Browser, LaunchOptions};
+use headless_chrome::{process, browser::{Browser, LaunchOptions}};
 
-let browser = Browser::new(LaunchOptions {  
-    headless: true,  
-    path: "/usr/bin/google-chrome", // BYO Chrome binary
-   ..Default::default()  
-})?;  
+fn browse_wikipedia() -> Result<(), failure::Error> {
+    let options = process::LaunchOptions::default().expect("Failed to find chrome");
+    let browser = Browser::new(options)?;
 
-let tab = browser.wait_for_initial_tab()?;
-	
-tab.navigate_to("https://www.wikipedia.org")?;  
-  
-tab.wait_for_element("input#searchInput")?.click()?;
-  
-tab.type_str("WebKit")?;  
-tab.press_key("Enter")?;  
-  
-tab.wait_for_element("#firstHeading")?;  
-  
-assert_eq!(true, tab.get_url().ends_with("WebKit"));
+    let tab = browser.wait_for_initial_tab()?;
+
+    tab.navigate_to("https://www.wikipedia.org")?;
+
+    tab.wait_for_element("input#searchInput")?
+       .click()?;
+    tab.type_str("WebKit")?
+       .press_key("Enter")?;
+
+    tab.wait_for_element("#firstHeading")?;
+    assert_eq!(true, tab.get_url().ends_with("WebKit"));
+    Ok(())
+}
+
+assert!(browse_wikipedia().is_ok());
 ```
 
-For fuller examples, take a look at `tests/integration.rs`.
+For fuller examples, take a look at `tests/simple.rs`.
 
 ## Missing features
 * Documentation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "nightly", feature(external_doc))]
+
 extern crate log;
 extern crate termcolor;
 
@@ -15,3 +17,8 @@ pub mod waiting_call_registry;
 pub mod web_socket_connection;
 
 pub use browser::{Browser, LaunchOptions};
+
+#[cfg(feature = "nightly")]
+#[doc(include = "../README.md")]
+#[allow(dead_code)]
+type _READMETEST = ();


### PR DESCRIPTION
This allows testing the code example in `README.md`, at least under nightly as `external_doc` is not stable yet. The current `README.md` did not compile.