### PR TITLE
Convert NodeAttributes to Map, add Node fields

### DIFF
--- a/src/cdtp/dom.rs
+++ b/src/cdtp/dom.rs
@@ -84,10 +84,9 @@ where
     let opt: Option<Vec<String>> = Option::deserialize(d)?;
     Ok(opt.map(|attr| {
         let mut map = HashMap::new();
-        let mut i = 0;
-        while i < attr.len() - 1 {
-            map.insert(attr[i].clone(), attr[i + 1].clone());
-            i += 2;
+        let mut iter = attr.into_iter();
+        while let Some(n) = iter.next() {
+            map.insert(n, iter.next().unwrap());
         }
         map
     }))


### PR DESCRIPTION
closes: #18 
closes: #19 
If it's possible to implement that custom deserialize without an explicit clone on the values I wasn't able to do it. I get a 'cannot move out of borrowed content' borrowck error if I don't clone. Any ideas?

Something I learned: when you do custom deserialize for Option values you need `#[serde(default, ... )]` otherwise serde will panic. I tested this out on a few pages to make sure it could print node attributes properly.