### PR TITLE
Improve screenshot API, add example

### DIFF
--- a/examples/take_screenshot.rs
+++ b/examples/take_screenshot.rs
@@ -1,0 +1,17 @@
+//! Create a headless browser, navigate to wikipedia, wait for the page
+//! to render completely, take a screenshot in JPEG-format using 75% quality
+use headless_chrome::{cdtp::page::ScreenshotFormat, Browser, LaunchOptions};
+use std::fs;
+
+fn main() -> Result<(), failure::Error> {
+    let opts = LaunchOptions::default().expect("Could not find chrome");
+    let browser = Browser::new(opts)?;
+    let jpeg_data = browser
+        .wait_for_initial_tab()?
+        .navigate_to("https://www.wikipedia.org")?
+        .wait_until_navigated()?
+        .capture_screenshot(ScreenshotFormat::JPEG(Some(75)), true)?;
+    fs::write("screenshot.jpg", &jpeg_data)?;
+    println!("Screenshot successfully created.");
+    Ok(())
+}

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -19,7 +19,6 @@ use crate::cdtp::Event;
 
 use super::waiting_helpers::{wait_for, WaitOptions};
 
-use crate::cdtp::page::ScreenshotFormat;
 use element::Element;
 use point::Point;
 
@@ -322,17 +321,20 @@ impl<'a> Tab {
 
     /// Capture a screenshot of the current page.
     ///
-    /// If `format` is not given, Chrome will default to PNG.
-    /// `quality` has to be an integer in the range [0..100] and only applies to JPEG.
     /// If `from_surface` is true, the screenshot is taken from the surface rather than
-    /// the view; this is the default.
+    /// the view.
     pub fn capture_screenshot(
         &self,
-        format: Option<ScreenshotFormat>,
-        quality: Option<u8>,
-        from_surface: Option<bool>,
+        format: page::ScreenshotFormat,
+        from_surface: bool,
     ) -> Result<Vec<u8>, Error> {
         // TODO: Implement `clip`-argument
+        let (format, quality) = match format {
+            page::ScreenshotFormat::JPEG(quality) => {
+                (page::InternalScreenshotFormat::JPEG, quality)
+            }
+            page::ScreenshotFormat::PNG => (page::InternalScreenshotFormat::PNG, None),
+        };
         let data = self
             .call_method(page::methods::CaptureScreenshot {
                 format,

--- a/src/cdtp/page.rs
+++ b/src/cdtp/page.rs
@@ -13,11 +13,18 @@ pub struct Frame {
     pub unreachable_url: Option<String>,
 }
 
-/// The format a screenshot will be captured in
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Serialize)]
 #[serde(rename_all = "lowercase")]
-pub enum ScreenshotFormat {
+pub(crate) enum InternalScreenshotFormat {
     JPEG,
+    PNG,
+}
+
+/// The format a screenshot will be captured in
+#[derive(Debug, Clone)]
+pub enum ScreenshotFormat {
+    /// Optionally compression quality from range [0..100]
+    JPEG(Option<u8>),
     PNG,
 }
 
@@ -73,12 +80,11 @@ pub mod methods {
 
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
-    pub struct CaptureScreenshot {
-        pub format: Option<super::ScreenshotFormat>,
+    pub(crate) struct CaptureScreenshot {
+        pub format: super::InternalScreenshotFormat,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub quality: Option<u8>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub from_surface: Option<bool>,
+        pub from_surface: bool,
     }
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,5 +1,4 @@
-use headless_chrome::cdtp::page::ScreenshotFormat;
-use headless_chrome::{Browser, LaunchOptions, Tab};
+use headless_chrome::{cdtp::page::ScreenshotFormat, Browser, LaunchOptions, Tab};
 use std::sync::Arc;
 
 mod logging;
@@ -67,7 +66,7 @@ fn capture_screenshot() -> Result<(), failure::Error> {
     let (_, _browser, tab) = dumb_server(include_str!("simple.html"));
     tab.wait_until_navigated()?;
 
-    let png_data = tab.capture_screenshot(Some(ScreenshotFormat::PNG), None, None)?;
+    let png_data = tab.capture_screenshot(ScreenshotFormat::PNG, true)?;
     let decoder = png::Decoder::new(&png_data[..]);
     let (info, mut reader) = decoder.read_info()?;
     let mut buf = vec![0; info.buffer_size()];
@@ -75,7 +74,7 @@ fn capture_screenshot() -> Result<(), failure::Error> {
     // Check that the top-left pixel has the background color set in simple.html
     assert_eq!(buf[0..4], [0x11, 0x22, 0x33, 0xff][..]);
 
-    let jpg_data = tab.capture_screenshot(Some(ScreenshotFormat::JPEG), Some(100), Some(false))?;
+    let jpg_data = tab.capture_screenshot(ScreenshotFormat::JPEG(Some(100)), true)?;
     let mut decoder = jpeg_decoder::Decoder::new(&jpg_data[..]);
     let buf = decoder.decode().unwrap();
     // Check that the total compression error is small-ish compared to the expected
@@ -83,8 +82,8 @@ fn capture_screenshot() -> Result<(), failure::Error> {
     let err = buf[0..3]
         .iter()
         .zip(&[0x11, 0x22, 0x33])
-        .map(|(b, e)| (i16::from(*b) - e).pow(2) as u16)
-        .sum::<u16>();
+        .map(|(b, e)| (i32::from(*b) - e).pow(2) as u32)
+        .sum::<u32>();
     assert!(err < 5);
     Ok(())
 }


### PR DESCRIPTION
This fixes the test being broken on MacOS for some reason (the screenshot taken from the view is just 1x1 pixel), improves the API (no optional parameters that sometimes get ignored, sometimes not) and adds an executable example.