### PR TITLE
Two small fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ rand = "0.6"
 tempfile = "3"
 toml = "0.4"
 chrono = "0.4"
-termcolor = "1"
-which = "2.0.1"
+which = "2.0"
 base64 = "0.10"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [Puppeteer](https://github.com/GoogleChrome/puppeteer) for Rust. It looks a little something like this:
 
 ```rust
-use headless_chrome::browser::{Browser, LaunchOptions};
+use headless_chrome::{Browser, LaunchOptions};
 
 fn browse_wikipedia() -> Result<(), failure::Error> {
     let options = LaunchOptions::default().expect("Failed to find chrome");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 
 extern crate log;
-extern crate termcolor;
 
 mod browser;
 pub mod cdtp;


### PR DESCRIPTION
The `termcolor`-crate should be unneeded (and is in fact); if downstream wants colored output, they can always do that.

README has been broken by recent changes