### PR TITLE
Add query_wikipedia example

### DIFF
--- a/examples/query_wikipedia.rs
+++ b/examples/query_wikipedia.rs
@@ -1,0 +1,24 @@
+use headless_chrome::{Browser, LaunchOptions};
+
+fn query(input: &str) -> Result<(), failure::Error> {
+    let browser =
+        Browser::new(LaunchOptions::default().expect("Could not find chrome-executable"))?;
+    let tab = browser.wait_for_initial_tab()?;
+    tab.navigate_to("https://en.wikipedia.org")?
+        .wait_for_element("input#searchInput")?
+        .click()?;
+    tab.type_str(&input)?.press_key("Enter")?;
+    match tab.wait_for_element("div.shortdescription") {
+        Err(e) => eprintln!("Query failed: {:?}", e),
+        Ok(e) => match e.get_description()?.find(|n| n.node_name == "#text") {
+            Some(n) => println!("Result for `{}`: {}", &input, n.node_value),
+            None => eprintln!("No shortdescription-node found on page"),
+        },
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), failure::Error> {
+    let input = "Elvis Aaron Presley";
+    query(input)
+}


### PR DESCRIPTION
A free-standing version of whats in `real_world.rs`.

I noticed that `tab.wait_for_element()` and especially `tab.find_element()` can return an error `NoElementFound` that is no longer public and therefor can't be matched against. We currently can't distinguish if the element is simply not there or if the browser failed in some other way.