### PR TITLE
Use the builder pattern for launch options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ toml = "0.4"
 chrono = "0.4"
 which = "2.0"
 base64 = "0.10"
+derive_builder = "0.7.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6"

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 [Puppeteer](https://github.com/GoogleChrome/puppeteer) for Rust. It looks a little something like this:
 
 ```rust
-use headless_chrome::{Browser, LaunchOptions};
+use headless_chrome::{Browser, LaunchOptionsBuilder};
 
 fn browse_wikipedia() -> Result<(), failure::Error> {
-    let options = LaunchOptions::default().expect("Failed to find chrome");
+    let options = LaunchOptionsBuilder::default().unwrap().expect("Failed to find chrome");
     let browser = Browser::new(options)?;
 
     let tab = browser.wait_for_initial_tab()?;

--- a/examples/real_world.rs
+++ b/examples/real_world.rs
@@ -5,7 +5,7 @@ use failure::Error;
 use log::*;
 use toml;
 
-use headless_chrome::{Browser, LaunchOptions, Tab};
+use headless_chrome::{Browser, LaunchOptionsBuilder, Tab};
 use rand::distributions::Alphanumeric;
 use rand::{self, Rng};
 use std::sync::Arc;
@@ -37,7 +37,9 @@ fn rand_ascii() -> String {
 }
 
 fn default_browser_and_tab() -> (Browser, Arc<Tab>) {
-    let options = LaunchOptions::default().expect("Couldn't find appropriate Chrome binary.");
+    let options = LaunchOptionsBuilder::default()
+        .build()
+        .expect("Couldn't find appropriate Chrome binary.");
     let browser = Browser::new(options).expect("Failed to launch and connect to Chrome");
     let tab = browser
         .wait_for_initial_tab()

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -9,8 +9,8 @@ use serde;
 use crate::cdtp::target::methods::{CreateTarget, SetDiscoverTargets};
 use crate::cdtp::{self, Event};
 
-pub use process::LaunchOptions;
-use process::Process;
+pub use process::LaunchOptionsBuilder;
+use process::{LaunchOptions, Process};
 pub use tab::Tab;
 use transport::Transport;
 use waiting_helpers::{wait_for, WaitOptions};

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -50,21 +50,27 @@ impl Drop for TemporaryProcess {
 
 /// Represents the way in which Chrome is run. By default it will search for a Chrome
 /// binary on the system, use an available port for debugging, and start in headless mode.
+#[derive(Builder)]
 pub struct LaunchOptions {
-    pub headless: bool,
-    pub port: Option<u16>,
-    pub path: std::path::PathBuf,
+    #[builder(default = "true")]
+    headless: bool,
+
+    #[builder(default = "None")]
+    port: Option<u16>,
+
+    #[builder(default = "self.default_executable()?")]
+    path: std::path::PathBuf,
 }
 
-impl LaunchOptions {
-    pub fn default_executable() -> Option<std::path::PathBuf> {
+impl LaunchOptionsBuilder {
+    fn default_executable(&self) -> Result<std::path::PathBuf, String> {
         // TODO Look at $BROWSER and if it points to a chrome binary
         // $BROWSER may also provide default arguments, which we may
         // or may not override later on.
 
         for app in &["google-chrome-stable", "chromium"] {
             if let Ok(path) = which(app) {
-                return Some(path);
+                return Ok(path);
             }
         }
 
@@ -74,7 +80,7 @@ impl LaunchOptions {
                 &["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"][..];
             for path in default_paths {
                 if std::path::Path::new(path).exists() {
-                    return Some(path.into());
+                    return Ok(path.into());
                 }
             }
         }
@@ -83,35 +89,12 @@ impl LaunchOptions {
         {
             if let Some(path) = get_chrome_path_from_registry() {
                 if path.exists() {
-                    return Some(path);
+                    return Ok(path);
                 }
             }
         }
 
-        None
-    }
-
-    pub fn default() -> Option<Self> {
-        Some(LaunchOptions {
-            headless: true,
-            port: None,
-            path: Self::default_executable()?,
-        })
-    }
-
-    pub fn headless(mut self, headless: bool) -> Self {
-        self.headless = headless;
-        self
-    }
-
-    pub fn port(mut self, port: Option<u16>) -> Self {
-        self.port = port;
-        self
-    }
-
-    pub fn path(mut self, path: std::path::PathBuf) -> Self {
-        self.path = path;
-        self
+        Err("Could not auto detect a chrome executable".to_string())
     }
 }
 
@@ -255,6 +238,7 @@ fn port_is_available(port: u16) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::thread;
 
     #[cfg(target_os = "linux")]
@@ -280,10 +264,10 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn kills_process_on_drop() {
-        use super::LaunchOptions;
         env_logger::try_init().unwrap_or(());
         {
-            let _chrome = &mut super::Process::new(LaunchOptions::default().unwrap()).unwrap();
+            let _chrome =
+                &mut super::Process::new(LaunchOptionsBuilder::default().build().unwrap()).unwrap();
         }
 
         let child_pids = current_child_pids();
@@ -300,7 +284,8 @@ mod tests {
             let handle = thread::spawn(|| {
                 // these sleeps are to make it more likely the chrome startups will overlap
                 std::thread::sleep(std::time::Duration::from_millis(10));
-                let chrome = super::Process::new(super::LaunchOptions::default().unwrap()).unwrap();
+                let chrome =
+                    super::Process::new(LaunchOptionsBuilder::default().build().unwrap()).unwrap();
                 std::thread::sleep(std::time::Duration::from_millis(100));
                 chrome.debug_ws_url.clone()
             });
@@ -319,9 +304,13 @@ mod tests {
         let mut handles = Vec::new();
 
         for _ in 0..10 {
-            let chrome =
-                super::Process::new(super::LaunchOptions::default().unwrap().headless(false))
-                    .unwrap();
+            let chrome = super::Process::new(
+                super::LaunchOptionsBuilder::default()
+                    .headless(false)
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
             handles.push(chrome);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,13 @@
 
 extern crate log;
 
+#[macro_use]
+extern crate derive_builder;
+
 mod browser;
 pub mod cdtp;
 
-pub use browser::{Browser, LaunchOptions, Tab};
+pub use browser::{Browser, LaunchOptionsBuilder, Tab};
 
 #[cfg(feature = "nightly")]
 #[doc(include = "../README.md")]

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,5 +1,5 @@
 use headless_chrome::cdtp::page::ScreenshotFormat;
-use headless_chrome::{Browser, LaunchOptions, Tab};
+use headless_chrome::{Browser, LaunchOptionsBuilder, Tab};
 use std::sync::Arc;
 
 mod logging;
@@ -17,7 +17,7 @@ fn dumb_server(data: &'static str) -> (server::Server, Browser, Arc<Tab>) {
 }
 
 fn dumb_client(server: &server::Server) -> (Browser, Arc<Tab>) {
-    let browser = Browser::new(LaunchOptions::default().unwrap()).unwrap();
+    let browser = Browser::new(LaunchOptionsBuilder::default().build().unwrap()).unwrap();
     let tab = browser.wait_for_initial_tab().unwrap();
     tab.navigate_to(&format!("http://127.0.0.1:{}", server.port()))
         .unwrap();


### PR DESCRIPTION
Using the builder pattern means that the auto detection function will only run if the path was not specified.