### PR TITLE
WIP: Implement clip on captureScreenshot

### DIFF
--- a/examples/take_screenshot.rs
+++ b/examples/take_screenshot.rs
@@ -1,19 +1,28 @@
-//! Create a headless browser, navigate to wikipedia, wait for the page
-//! to render completely, take a screenshot in JPEG-format using 75% quality
 use headless_chrome::{cdtp::page::ScreenshotFormat, Browser, LaunchOptionsBuilder};
 use std::fs;
 
 fn main() -> Result<(), failure::Error> {
+    // Create a headless browser, navigate to wikipedia.org, wait for the page
+    // to render completely, take a screenshot of the entire page
+    // in JPEG-format using 75% quality.
     let options = LaunchOptionsBuilder::default()
         .build()
         .expect("Couldn't find appropriate Chrome binary.");
-    let browser = Browser::new(options).expect("Failed to launch and connect to Chrome");
-    let jpeg_data = browser
-        .wait_for_initial_tab()?
+    let browser = Browser::new(options)?;
+    let tab = browser.wait_for_initial_tab()?;
+    let jpeg_data = tab
         .navigate_to("https://www.wikipedia.org")?
         .wait_until_navigated()?
-        .capture_screenshot(ScreenshotFormat::JPEG(Some(75)), true)?;
+        .capture_screenshot(ScreenshotFormat::JPEG(Some(75)), None, true)?;
     fs::write("screenshot.jpg", &jpeg_data)?;
-    println!("Screenshot successfully created.");
+
+    // Browse to the WebKit-Page and take a screenshot of the infobox.
+    let png_data = tab
+        .navigate_to("https://en.wikipedia.org/wiki/WebKit")?
+        .wait_for_element("#mw-content-text > div > table.infobox.vevent")?
+        .capture_screenshot(ScreenshotFormat::PNG)?;
+    fs::write("screenshot.png", &png_data)?;
+
+    println!("Screenshots successfully created.");
     Ok(())
 }

--- a/src/cdtp/page.rs
+++ b/src/cdtp/page.rs
@@ -20,6 +20,21 @@ pub(crate) enum InternalScreenshotFormat {
     PNG,
 }
 
+/// Viewport for capturing screenshot.
+#[derive(Debug, Clone, Serialize)]
+pub struct Viewport {
+    /// X offset in device independent pixels
+    pub x: f64,
+    /// Y offset in device independent pixels
+    pub y: f64,
+    /// Rectangle width in device independent pixels
+    pub width: f64,
+    /// Rectangle height in device independent pixels
+    pub height: f64,
+    /// Page scale factor
+    pub scale: f64,
+}
+
 /// The format a screenshot will be captured in
 #[derive(Debug, Clone)]
 pub enum ScreenshotFormat {
@@ -84,6 +99,8 @@ pub mod methods {
         pub format: super::InternalScreenshotFormat,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub quality: Option<u8>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub clip: Option<super::Viewport>,
         pub from_surface: bool,
     }
     #[derive(Debug, Deserialize)]

--- a/tests/simple.html
+++ b/tests/simple.html
@@ -8,8 +8,9 @@ body {
 div#foobar {
     height: 20px;
     width: 100px;
-    margin: 1px;
-    background: red;
+    margin: 10px;
+    border: 3px solid #221133;
+    background: #332211;
 }
 </style>
     </head>

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -28,7 +28,7 @@ fn dumb_client(server: &server::Server) -> (Browser, Arc<Tab>) {
 #[test]
 fn simple() -> Result<(), failure::Error> {
     logging::enable_logging();
-    let (_server, _browser, tab) = dumb_server(include_str!("simple.html"));
+    let (_, _, tab) = dumb_server(include_str!("simple.html"));
     tab.wait_for_element("div#foobar")?;
     Ok(())
 }
@@ -47,16 +47,13 @@ fn actions_on_tab_wont_hang_after_browser_drops() -> Result<(), failure::Error> 
         });
         let _element = tab.find_element("div#foobar");
     }
-
-    // We terminate
-    assert_eq!(true, true);
     Ok(())
 }
 
 #[test]
 fn form_interaction() -> Result<(), failure::Error> {
     logging::enable_logging();
-    let (_server, _browser, tab) = dumb_server(include_str!("form.html"));
+    let (_, _, tab) = dumb_server(include_str!("form.html"));
     tab.wait_for_element("input#target")?
         .type_into("mothership")?;
     tab.wait_for_element("button")?.click()?;
@@ -73,26 +70,65 @@ fn form_interaction() -> Result<(), failure::Error> {
     Ok(())
 }
 
-#[test]
-fn capture_screenshot() -> Result<(), failure::Error> {
-    logging::enable_logging();
-    let (_, _browser, tab) = dumb_server(include_str!("simple.html"));
-    tab.wait_until_navigated()?;
-
-    let png_data = tab.capture_screenshot(ScreenshotFormat::PNG, true)?;
-    let decoder = png::Decoder::new(&png_data[..]);
+fn decode_png(i: &[u8]) -> Result<Vec<u8>, failure::Error> {
+    let decoder = png::Decoder::new(&i[..]);
     let (info, mut reader) = decoder.read_info()?;
     let mut buf = vec![0; info.buffer_size()];
     reader.next_frame(&mut buf)?;
-    // Check that the top-left pixel has the background color set in simple.html
-    assert_eq!(buf[0..4], [0x11, 0x22, 0x33, 0xff][..]);
+    Ok(buf)
+}
 
-    let jpg_data = tab.capture_screenshot(ScreenshotFormat::JPEG(Some(100)), true)?;
+#[test]
+fn capture_screenshot_png() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let (_, _, tab) = dumb_server(include_str!("simple.html"));
+    tab.wait_until_navigated()?;
+    // Check that the top-left pixel on the page has the background color set in simple.html
+    let png_data = tab.capture_screenshot(ScreenshotFormat::PNG, None, true)?;
+    let buf = decode_png(&png_data[..])?;
+    assert_eq!(buf[0..4], [0x11, 0x22, 0x33, 0xff][..]);
+    Ok(())
+}
+
+#[test]
+fn capture_screenshot_element() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let (_, _, tab) = dumb_server(include_str!("simple.html"));
+    // Check that the screenshot of the div's content-box has no other color than the one set in simple.html
+    let png_data = tab
+        .wait_for_element("div#foobar")?
+        .capture_screenshot(ScreenshotFormat::PNG)?;
+    let buf = decode_png(&png_data[..])?;
+    for i in 0..buf.len() / 4 {
+        assert_eq!(buf[i * 4..(i + 1) * 4], [0x33, 0x22, 0x11, 0xff][..]);
+    }
+    Ok(())
+}
+
+#[test]
+fn capture_screenshot_element_box() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let (_, _, tab) = dumb_server(include_str!("simple.html"));
+    // Check that the top-left pixel of the div's border-box has the border's color set in simple.html
+    let pox = tab.wait_for_element("div#foobar")?.get_box_model()?;
+    let png_data =
+        tab.capture_screenshot(ScreenshotFormat::PNG, Some(pox.border_viewport()), true)?;
+    let buf = decode_png(&png_data[..])?;
+    assert_eq!(buf[0..4], [0x22, 0x11, 0x33, 0xff][..]);
+    Ok(())
+}
+
+#[test]
+fn capture_screenshot_jpeg() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let (_, _, tab) = dumb_server(include_str!("simple.html"));
+    tab.wait_until_navigated()?;
+    let jpg_data = tab.capture_screenshot(ScreenshotFormat::JPEG(Some(100)), None, true)?;
     let mut decoder = jpeg_decoder::Decoder::new(&jpg_data[..]);
     let buf = decoder.decode().unwrap();
     // Check that the total compression error is small-ish compared to the expected
     // pixel color
-    let err = buf[0..3]
+    let err = buf
         .iter()
         .zip(&[0x11, 0x22, 0x33])
         .map(|(b, e)| (i32::from(*b) - e).pow(2) as u32)
@@ -104,11 +140,11 @@ fn capture_screenshot() -> Result<(), failure::Error> {
 #[test]
 fn get_box_model() -> Result<(), failure::Error> {
     logging::enable_logging();
-    let (_, _browser, tab) = dumb_server(include_str!("simple.html"));
+    let (_, _, tab) = dumb_server(include_str!("simple.html"));
     let pox = tab.wait_for_element("div#foobar")?.get_box_model()?;
     // Check that the div has exactly the dimensions we set in simple.html
-    assert_eq!(pox.width, 100);
-    assert_eq!(pox.height, 20);
+    assert_eq!(pox.width, 3+100+3);
+    assert_eq!(pox.height, 3+20+3);
     Ok(())
 }
 
@@ -129,7 +165,7 @@ fn reload() -> Result<(), failure::Error> {
         r.respond(response)
     };
     let server = server::Server::new(responder);
-    let (_browser, tab) = dumb_client(&server);
+    let (_, tab) = dumb_client(&server);
     assert!(tab
         .wait_for_element("div#counter")?
         .get_description()?


### PR DESCRIPTION
Here is an implementation of the `clip` argument on `captureScreenshot`, which allows taking a screenshot of specific regions on the page. The functionality has been hotwired to `tab::Element` so one can do `tab.wait_for_element("div#foobar")?.capture_screenshot(ScreenshotFormat::PNG)?` to get a screenshot of that specific element. See `capture_screenshot_element_box()` for how to do this in a more fine-grained way. Docs, tests and examples were expanded.

Two problems remain:

* `tab::Element` is not public and so it's not documented, neither are `BoxModel`, `ElementQuad` etc. This is the same problem as with `NoElementFound` returned by `tab.find_element()`.
* The integration tests all fail in mysterious and flaky ways. Most of the time they just time out, sometimes `transport` complains about not being able to communicate. The tests seem to be stable if executed `--test-threads 1`. Recent changes broke something?
