### PR TITLE
Enable most of clippy::pedantic by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ addons:
 
 script:
   - cargo fmt --all -- --check
-  - cargo clippy --tests
+  - cargo clippy --all --tests --examples
   - env RUST_BACKTRACE=1 RUST_LOG=headless_chrome=trace cargo test -- --nocapture

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -234,6 +234,7 @@ impl Browser {
     #[allow(dead_code)]
     #[cfg(test)]
     pub(crate) fn process(&self) -> &Process {
+        #[allow(clippy::used_underscore_binding)]
         &self._process
     }
 }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -61,16 +61,16 @@ impl Browser {
     /// The browser will have its user data (aka "profile") directory stored in a temporary directory.
     /// The browser process will be killed when this struct is dropped.
     pub fn new(launch_options: LaunchOptions) -> Result<Self, Error> {
-        let _process = Process::new(launch_options)?;
+        let process = Process::new(launch_options)?;
 
-        let transport = Arc::new(Transport::new(_process.debug_ws_url.clone())?);
+        let transport = Arc::new(Transport::new(process.debug_ws_url.clone())?);
 
         trace!("created transport");
 
         let tabs = Arc::new(Mutex::new(vec![]));
 
-        let browser = Browser {
-            _process,
+        let browser = Self {
+            _process: process,
             tabs,
             transport,
         };
@@ -209,7 +209,9 @@ impl Browser {
                                     updated_tab.update_target_info(target_info);
                                 }
                             }
-                            Event::TargetDestroyed(_) => {}
+                            Event::TargetDestroyed(ev) => {
+                                trace!("Target destroyed: {:?}", ev.params.target_id);
+                            }
                             _ => {}
                         }
                     }

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -114,7 +114,7 @@ impl Process {
     pub fn new(launch_options: LaunchOptions) -> Result<Self, Error> {
         info!("Trying to start Chrome");
 
-        let mut process = Process::start_process(&launch_options)?;
+        let mut process = Self::start_process(&launch_options)?;
 
         info!("Started Chrome. PID: {}", process.0.id());
 
@@ -125,7 +125,7 @@ impl Process {
                 return Err(ChromeLaunchError::NoAvailablePorts {}.into());
             }
 
-            match Process::ws_url_from_output(process.0.borrow_mut()) {
+            match Self::ws_url_from_output(process.0.borrow_mut()) {
                 Ok(debug_ws_url) => {
                     url = debug_ws_url;
                     break;
@@ -133,7 +133,7 @@ impl Process {
                 Err(error) => {
                     trace!("Problem getting WebSocket URL from Chrome: {}", error);
                     if launch_options.port.is_none() {
-                        process = Process::start_process(&launch_options)?;
+                        process = Self::start_process(&launch_options)?;
                     } else {
                         return Err(error);
                     }
@@ -147,7 +147,7 @@ impl Process {
             attempts += 1;
         }
 
-        Ok(Process {
+        Ok(Self {
             _child_process: process,
             debug_ws_url: url,
         })

--- a/src/browser/tab/element.rs
+++ b/src/browser/tab/element.rs
@@ -17,7 +17,7 @@ pub struct ElementQuad {
 
 impl ElementQuad {
     pub fn from_raw_points(raw_quad: &[f64; 8]) -> Self {
-        ElementQuad {
+        Self {
             top_left: Point {
                 x: raw_quad[0],
                 y: raw_quad[1],

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -65,7 +65,7 @@ impl<'a> Tab {
 
         let target_info_mutex = Arc::new(Mutex::new(target_info));
 
-        let tab = Tab {
+        let tab = Self {
             target_id,
             transport,
             session_id,
@@ -104,7 +104,7 @@ impl<'a> Tab {
         std::thread::spawn(move || {
             for event in incoming_events_rx {
                 trace!("{:?}", &event);
-                if let Event::LifecycleEvent(lifecycle_event) = event {
+                if let Event::Lifecycle(lifecycle_event) = event {
                     //                        if lifecycle_event.params.frame_id == main_frame_id {
                     match lifecycle_event.params.name.as_ref() {
                         "networkAlmostIdle" => {

--- a/src/browser/tab/point.rs
+++ b/src/browser/tab/point.rs
@@ -5,10 +5,10 @@ pub struct Point {
 }
 
 impl std::ops::Add<Point> for Point {
-    type Output = Point;
+    type Output = Self;
 
-    fn add(self, other: Point) -> Point {
-        Point {
+    fn add(self, other: Self) -> Self {
+        Self {
             x: self.x + other.x,
             y: self.y + other.y,
         }
@@ -16,10 +16,10 @@ impl std::ops::Add<Point> for Point {
 }
 
 impl std::ops::Sub<Point> for Point {
-    type Output = Point;
+    type Output = Self;
 
-    fn sub(self, other: Point) -> Point {
-        Point {
+    fn sub(self, other: Self) -> Self {
+        Self {
             x: self.x - other.x,
             y: self.y - other.y,
         }
@@ -27,10 +27,10 @@ impl std::ops::Sub<Point> for Point {
 }
 
 impl std::ops::Div<f64> for Point {
-    type Output = Point;
+    type Output = Self;
 
-    fn div(self, other: f64) -> Point {
-        Point {
+    fn div(self, other: f64) -> Self {
+        Self {
             x: self.x / other,
             y: self.y / other,
         }

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -85,7 +85,7 @@ impl Transport {
             Arc::clone(&web_socket_connection),
         );
 
-        Ok(Transport {
+        Ok(Self {
             web_socket_connection,
             waiting_call_registry,
             listeners,

--- a/src/browser/transport/web_socket_connection.rs
+++ b/src/browser/transport/web_socket_connection.rs
@@ -20,7 +20,7 @@ impl WebSocketConnection {
         ws_url: &str,
         target_messages_tx: mpsc::Sender<cdtp::Message>,
     ) -> Result<Self, Error> {
-        let connection = WebSocketConnection::websocket_connection(&ws_url)?;
+        let connection = Self::websocket_connection(&ws_url)?;
         let (websocket_receiver, sender) = connection.split()?;
 
         std::thread::spawn(move || {
@@ -29,7 +29,7 @@ impl WebSocketConnection {
             trace!("Quit loop msg dispatching loop");
         });
 
-        Ok(WebSocketConnection {
+        Ok(Self {
             sender: Mutex::new(sender),
         })
     }

--- a/src/cdtp/mod.rs
+++ b/src/cdtp/mod.rs
@@ -148,12 +148,9 @@ mod tests {
             }
         });
 
-        let event: Event = serde_json::from_value(attached_to_target_json).unwrap();
-        match event {
-            Event::AttachedToTarget(_) => {}
-            _ => {
-                panic!("bad news");
-            }
+        if let Ok(Event::AttachedToTarget(_)) = serde_json::from_value(attached_to_target_json) {
+        } else {
+            panic!("Failed to parse event properly");
         }
 
         let received_target_msg_event = json!({

--- a/src/cdtp/mod.rs
+++ b/src/cdtp/mod.rs
@@ -87,7 +87,7 @@ pub enum Event {
     #[serde(rename = "Page.frameStoppedLoading")]
     FrameStoppedLoading(page::events::FrameStoppedLoadingEvent),
     #[serde(rename = "Page.lifecycleEvent")]
-    LifecycleEvent(page::events::LifecycleEvent),
+    Lifecycle(page::events::LifecycleEvent),
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 #![deny(clippy::pedantic)]
 #![allow(
     clippy::stutter,
-    clippy::doc_markdown,
-    clippy::default_trait_access,
-    clippy::needless_pass_by_value
+    clippy::doc_markdown, // a number of false positives here
+    clippy::default_trait_access, // fails on output of derive_builder
+    clippy::needless_pass_by_value // would stop us creating and passing in LaunchOptions to browser in one statement
 )]
 
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "nightly", feature(external_doc))]
+#![deny(clippy::all)]
 
 extern crate log;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,11 @@
 #![cfg_attr(feature = "nightly", feature(external_doc))]
-#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+#![allow(
+    clippy::stutter,
+    clippy::doc_markdown,
+    clippy::default_trait_access,
+    clippy::needless_pass_by_value
+)]
 
 extern crate log;
 


### PR DESCRIPTION
```rust
#![deny(clippy::pedantic)]
#![allow(
    clippy::stutter,
    clippy::doc_markdown, // a number of false positives here
    clippy::default_trait_access, // fails on output of derive_builder
    clippy::needless_pass_by_value // would stop us creating and passing in LaunchOptions to browser in one statement
)]
```

Fixes #72 