### PR TITLE
Add BoxModel-helpers

### DIFF
--- a/src/browser/tab/element.rs
+++ b/src/browser/tab/element.rs
@@ -49,6 +49,130 @@ impl ElementQuad {
     pub fn aspect_ratio(&self) -> f64 {
         self.width() / self.height()
     }
+
+    /// If the most bottom point of `self` is above the most top point of `other`
+    pub fn is_strictly_above(&self, other: &Self) -> bool {
+        self.top_right
+            .y
+            .max(self.top_left.y)
+            .max(self.bottom_right.y)
+            .max(self.bottom_left.y)
+            < other
+                .top_right
+                .y
+                .min(other.top_left.y)
+                .min(other.bottom_right.y)
+                .min(other.bottom_left.y)
+    }
+
+    /// If the most bottom point of `self` is above or on the same line as the
+    /// most top point of `other`
+    pub fn is_above(&self, other: &Self) -> bool {
+        self.top_right
+            .y
+            .max(self.top_left.y)
+            .max(self.bottom_right.y)
+            .max(self.bottom_left.y)
+            <= other
+                .top_right
+                .y
+                .min(other.top_left.y)
+                .min(other.bottom_right.y)
+                .min(other.bottom_left.y)
+    }
+
+    /// If the most top point of `self` is below the most bottom point of `other`
+    pub fn is_strictly_below(&self, other: &Self) -> bool {
+        self.top_right
+            .y
+            .min(self.top_left.y)
+            .min(self.bottom_right.y)
+            .min(self.bottom_left.y)
+            > other
+                .top_right
+                .y
+                .max(other.top_left.y)
+                .max(other.bottom_right.y)
+                .max(other.bottom_left.y)
+    }
+
+    /// If the most top point of `self` is below or on the same line as the
+    /// most bottom point of `other`
+    pub fn is_below(&self, other: &Self) -> bool {
+        self.top_right
+            .y
+            .min(self.top_left.y)
+            .min(self.bottom_right.y)
+            .min(self.bottom_left.y)
+            >= other
+                .top_right
+                .y
+                .max(other.top_left.y)
+                .max(other.bottom_right.y)
+                .max(other.bottom_left.y)
+    }
+
+    /// If the most right point of `self` is left of the most left point of `other`
+    pub fn is_strictly_left_of(&self, other: &Self) -> bool {
+        self.top_right
+            .x
+            .max(self.top_left.x)
+            .max(self.bottom_right.x)
+            .max(self.bottom_left.x)
+            < other
+                .top_right
+                .x
+                .min(other.top_left.x)
+                .min(other.bottom_right.x)
+                .min(other.bottom_left.x)
+    }
+
+    /// If the most right point of `self` is left or on the same line as the
+    /// most left point of `other`
+    pub fn is_left_of(&self, other: &Self) -> bool {
+        self.top_right
+            .x
+            .max(self.top_left.x)
+            .max(self.bottom_right.x)
+            .max(self.bottom_left.x)
+            <= other
+                .top_right
+                .x
+                .min(other.top_left.x)
+                .min(other.bottom_right.x)
+                .min(other.bottom_left.x)
+    }
+
+    /// If the most left point of `self` is right of the most right point of `other`
+    pub fn is_strictly_right_of(&self, other: &Self) -> bool {
+        self.top_right
+            .x
+            .min(self.top_left.x)
+            .min(self.bottom_right.x)
+            .min(self.bottom_left.x)
+            > other
+                .top_right
+                .x
+                .max(other.top_left.x)
+                .max(other.bottom_right.x)
+                .max(other.bottom_left.x)
+    }
+
+    /// If the most left point of `self` is right or on the same line as the
+    /// most right point of `other`
+    pub fn is_right_of(&self, other: &Self) -> bool {
+        self.top_right
+            .x
+            .min(self.top_left.x)
+            .min(self.bottom_right.x)
+            .min(self.bottom_left.x)
+            >= other
+                .top_right
+                .x
+                .max(other.top_left.x)
+                .max(other.bottom_right.x)
+                .max(other.bottom_left.x)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/tests/simple.html
+++ b/tests/simple.html
@@ -12,11 +12,69 @@ div#foobar {
     border: 3px solid #221133;
     background: #332211;
 }
+
+div#position-test {
+    position: relative;
+    background: red;
+    right: -50px;
+    top: 50px;
+    width: 50px;
+    height: 50px;
+}
+
+div#strictly-above {
+    margin-bottom: 10px;
+    position: absolute;
+    bottom: 50px;
+    height: 50px;
+    width: 50px;
+    background: green;
+}
+div#strictly-below {
+    margin-top: 10px;
+    position: absolute;
+    top: 50px;
+    height: 50px;
+    width: 50px;
+    background: green;
+}
+div#strictly-left {
+    margin-right: 10px;
+    position: absolute;
+    right: 50px;
+    height: 50px;
+    width: 50px;
+    background: green;
+}
+div#strictly-right {
+    margin-left: 10px;
+    position: absolute;
+    left: 50px;
+    height: 50px;
+    width: 50px;
+    background: green;
+}
+div#within {
+    margin: 5px;
+    position: absolute;
+    left: 5px;
+    top: 5px;
+    height: 30px;
+    width: 30px;
+    background: yellow;
+}
 </style>
     </head>
     <body>
         <div>
         <div id="foobar"></div>
+        </div>
+        <div id="position-test">
+            <div id="within"></div>
+            <div id="strictly-above"></div>
+            <div id="strictly-below"></div>
+            <div id="strictly-left"></div>
+            <div id="strictly-right"></div>
         </div>
     </body>
 </html>

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -151,6 +151,45 @@ fn get_box_model() -> Result<(), failure::Error> {
 }
 
 #[test]
+fn box_model_geometry() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let (_, browser, tab) = dumb_server(include_str!("simple.html"));
+    let center = tab.wait_for_element("div#position-test")?.get_box_model()?;
+    let above = tab
+        .wait_for_element("div#strictly-above")?
+        .get_box_model()?;
+    let below = tab
+        .wait_for_element("div#strictly-below")?
+        .get_box_model()?;
+    let left = tab.wait_for_element("div#strictly-left")?.get_box_model()?;
+    let right = tab
+        .wait_for_element("div#strictly-right")?
+        .get_box_model()?;
+
+    assert!(above.content.is_strictly_above(&center.content));
+    assert!(above.content.is_above(&center.content));
+    assert!(above.margin.is_above(&center.content));
+    assert!(!above.margin.is_strictly_above(&center.content));
+
+    assert!(below.content.is_strictly_below(&center.content));
+    assert!(below.content.is_below(&center.content));
+    assert!(below.margin.is_below(&center.content));
+    assert!(!below.margin.is_strictly_below(&center.content));
+
+    assert!(left.content.is_strictly_left_of(&center.content));
+    assert!(left.content.is_left_of(&center.content));
+    assert!(left.margin.is_left_of(&center.content));
+    assert!(!left.margin.is_strictly_left_of(&center.content));
+
+    assert!(right.content.is_strictly_right_of(&center.content));
+    assert!(right.content.is_right_of(&center.content));
+    assert!(right.margin.is_right_of(&center.content));
+    assert!(!right.margin.is_strictly_right_of(&center.content));
+
+    Ok(())
+}
+
+#[test]
 fn reload() -> Result<(), failure::Error> {
     logging::enable_logging();
     let mut counter = 0;


### PR DESCRIPTION
Some helper functions on `BoxModel` that are handy when writing tests downstream, to check simple geometry (e.g. "is this element roughtly where it's supposed to be")