### PR TITLE
Add wrappers for starting, stopping and taking JS coverage

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -378,27 +378,54 @@ impl<'a> Tab {
         Ok(self)
     }
 
-    /// Tells Chrome to start tracking which lines of JS have been executed.
+    /// Enables the profiler
+    pub fn enable_profiler(&self) -> Result<&Self, Error> {
+        self.call_method(profiler::methods::Enable {})?;
+
+        Ok(self)
+    }
+
+    /// Disables the profiler
+    pub fn disable_profiler(&self) -> Result<&Self, Error> {
+        self.call_method(profiler::methods::Disable {})?;
+
+        Ok(self)
+    }
+
+    /// Starts tracking which lines of JS have been executed
+    ///
+    /// Will return error unless `enable_profiler` has been called.
     ///
     /// Equivalent to hitting the record button in the "coverage" tab in Chrome DevTools.
     /// See the file `tests/coverage.rs` for an example.
+    ///
+    /// By default we enable the 'detailed' flag on StartPreciseCoverage, which enables block-level
+    /// granularity, and also enable 'call_count' (which when disabled always sets count to 1 or 0).
+    ///
     pub fn start_js_coverage(&self) -> Result<&Self, Error> {
-        self.call_method(profiler::methods::Enable {})?;
-
         self.call_method(profiler::methods::StartPreciseCoverage {
-            call_count: None,
+            call_count: Some(true),
             detailed: Some(true),
         })?;
         Ok(self)
     }
 
-    /// Tells Chrome to stop tracking which lines of JS have been executed.
+    /// Stops tracking which lines of JS have been executed
+    /// If you're finished with the profiler, don't forget to call `disable_profiler`.
     pub fn stop_js_coverage(&self) -> Result<&Self, Error> {
         self.call_method(profiler::methods::StopPreciseCoverage {})?;
         Ok(self)
     }
 
-    /// Returns info about which lines of JS have been executed since you last called this method
+    /// Collect coverage data for the current isolate, and resets execution counters.
+    ///
+    /// Precise code coverage needs to have started (see `start_js_coverage`).
+    ///
+    /// Will only send information about code that's been executed since this method was last
+    /// called, or (if this is the first time) since calling `start_js_coverage`.
+    /// Another way of thinking about it is: every time you call this, the call counts for
+    /// FunctionRanges are reset after returning.
+    ///
     /// The format of the data is a little unintuitive, see here for details:
     /// https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
     pub fn take_precise_js_coverage(&self) -> Result<Vec<profiler::ScriptCoverage>, Error> {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -9,6 +9,7 @@ pub mod browser;
 pub mod dom;
 pub mod input;
 pub mod page;
+pub mod profiler;
 pub mod runtime;
 pub mod target;
 

--- a/src/protocol/profiler.rs
+++ b/src/protocol/profiler.rs
@@ -1,12 +1,22 @@
 use serde::Deserialize;
 
+// TODO: use these aliases in other parts of the protocol module
+// From experimentation, it seems the protocol's integers are i32s.
+#[allow(dead_code)]
+type JsInt = i32;
+// For when we specifically want to guard against negative numbers.
+type JsUInt = u32;
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 /// Coverage data for a source range.
 pub struct CoverageRange {
-    pub start_offset: u16,
-    pub end_offset: u16,
-    pub count: u16,
+    /// JavaScript script source offset for the range start.
+    pub start_offset: JsUInt,
+    /// JavaScript script source offset for the range end.
+    pub end_offset: JsUInt,
+    /// Collected execution count of the source range.
+    pub count: JsUInt,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -43,6 +53,17 @@ pub mod methods {
     impl Method for Enable {
         const NAME: &'static str = "Profiler.enable";
         type ReturnObject = EnableReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Disable {}
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DisableReturnObject {}
+    impl Method for Disable {
+        const NAME: &'static str = "Profiler.disable";
+        type ReturnObject = DisableReturnObject;
     }
 
     #[derive(Serialize, Debug)]

--- a/src/protocol/profiler.rs
+++ b/src/protocol/profiler.rs
@@ -1,0 +1,87 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// Coverage data for a source range.
+pub struct CoverageRange {
+    pub start_offset: u16,
+    pub end_offset: u16,
+    pub count: u16,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// Coverage data for a JavaScript function.
+pub struct FunctionCoverage {
+    pub function_name: String,
+    /// Source ranges inside the function with coverage data.
+    pub ranges: Vec<CoverageRange>,
+}
+
+/// JS line coverage information for a single script
+/// See https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScriptCoverage {
+    pub script_id: String,
+    /// Either the name or URL of a script loaded by the page
+    pub url: String,
+    /// Functions contained in the script that has coverage data
+    pub functions: Vec<FunctionCoverage>,
+}
+
+pub mod methods {
+    use crate::protocol::Method;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Enable {}
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct EnableReturnObject {}
+    impl Method for Enable {
+        const NAME: &'static str = "Profiler.enable";
+        type ReturnObject = EnableReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct StartPreciseCoverage {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub call_count: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub detailed: Option<bool>,
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct StartPreciseCoverageReturnObject {}
+    impl Method for StartPreciseCoverage {
+        const NAME: &'static str = "Profiler.startPreciseCoverage";
+        type ReturnObject = StartPreciseCoverageReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct StopPreciseCoverage {}
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct StopPreciseCoverageReturnObject {}
+    impl Method for StopPreciseCoverage {
+        const NAME: &'static str = "Profiler.stopPreciseCoverage";
+        type ReturnObject = StopPreciseCoverageReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct TakePreciseCoverage {}
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct TakePreciseCoverageReturnObject {
+        pub result: Vec<super::ScriptCoverage>,
+    }
+    impl Method for TakePreciseCoverage {
+        const NAME: &'static str = "Profiler.takePreciseCoverage";
+        type ReturnObject = TakePreciseCoverageReturnObject;
+    }
+}

--- a/tests/coverage.rs
+++ b/tests/coverage.rs
@@ -1,0 +1,122 @@
+mod logging;
+mod server;
+
+use failure::Error;
+use headless_chrome::{Browser, LaunchOptionsBuilder};
+
+use headless_chrome::browser::tab::Tab;
+use server::Server;
+use std::sync::Arc;
+
+fn basic_http_response(
+    body: &'static str,
+    content_type: &'static str,
+) -> tiny_http::Response<&'static [u8]> {
+    tiny_http::Response::new(
+        200.into(),
+        vec![tiny_http::Header::from_bytes(&b"Content-Type"[..], content_type.as_bytes()).unwrap()],
+        body.as_bytes(),
+        Some(body.len()),
+        None,
+    )
+}
+
+fn server_with_html_and_js() -> Server {
+    Server::new(|request: tiny_http::Request| {
+        let url = request.url();
+
+        let content_type = if url.ends_with(".js") {
+            "application/javascript"
+        } else {
+            "text/html"
+        };
+
+        let body = if url.ends_with("coverage_fixture1.js") {
+            include_str!("coverage_fixtures/coverage_fixture1.js")
+        } else if url.ends_with("coverage_fixture2.js") {
+            include_str!("coverage_fixtures/coverage_fixture2.js")
+        } else {
+            include_str!("coverage_fixtures/basic_page_with_js_scripts.html")
+        };
+
+        let response = basic_http_response(body, content_type);
+        request.respond(response)
+    })
+}
+
+#[test]
+fn returns_actual_coverage() -> Result<(), Error> {
+    logging::enable_logging();
+    let server = server_with_html_and_js();
+    let browser = Browser::new(
+        LaunchOptionsBuilder::default()
+            .headless(true)
+            .build()
+            .unwrap(),
+    )
+    .unwrap();
+    let tab: Arc<Tab> = browser.wait_for_initial_tab()?;
+
+    tab.start_js_coverage()?;
+
+    let url = format!("http://127.0.0.1:{}", server.port());
+    tab.navigate_to(&url)?;
+
+    tab.wait_until_navigated()?;
+
+    let script_coverages = tab.take_precise_js_coverage()?;
+
+    // our fixtures HTML file (basic_page_with_js_scripts.html) includes two external scripts
+    assert_eq!(2, script_coverages.len());
+
+    let first_script = script_coverages
+        .iter()
+        .find(|script_coverage| script_coverage.url.ends_with("coverage_fixture1.js"))
+        .unwrap();
+
+    // in coverage_fixture1.js, there are two anonymous functions and one nameless "function" that
+    // you can imagine as being the global scope (i.e. the top level scope of the script)
+    assert_eq!(3, first_script.functions.len());
+
+    // this one should not have been executed yet:
+
+    let on_click_function_coverage = first_script
+        .functions
+        .iter()
+        .find(|function_coverage| function_coverage.function_name == "button.onclick")
+        .unwrap();
+
+    let fn_range = on_click_function_coverage.ranges.first().unwrap();
+    assert_eq!(fn_range.count, 0);
+
+    let button = tab.wait_for_element("#incrementor")?;
+    button.click()?;
+
+    let updated_script_coverages = tab.take_precise_js_coverage()?;
+
+    // when we clicked the button, code in only one of the scripts was executed, and Chrome
+    // only sends back info about code that's been executed since you last "took" the coverage:
+    assert_eq!(1, updated_script_coverages.len());
+
+    let updated_on_click_function_coverage = updated_script_coverages
+        .first()
+        .unwrap()
+        .functions
+        .first()
+        .unwrap();
+
+    assert_eq!(
+        "button.onclick",
+        updated_on_click_function_coverage.function_name
+    );
+    assert_eq!(
+        1,
+        updated_on_click_function_coverage
+            .ranges
+            .first()
+            .unwrap()
+            .count
+    );
+
+    Ok(())
+}

--- a/tests/coverage.rs
+++ b/tests/coverage.rs
@@ -57,6 +57,7 @@ fn returns_actual_coverage() -> Result<(), Error> {
     .unwrap();
     let tab: Arc<Tab> = browser.wait_for_initial_tab()?;
 
+    tab.enable_profiler()?;
     tab.start_js_coverage()?;
 
     let url = format!("http://127.0.0.1:{}", server.port());

--- a/tests/coverage_fixtures/basic_page_with_js_scripts.html
+++ b/tests/coverage_fixtures/basic_page_with_js_scripts.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+</head>
+<body>
+<button id="incrementor">
+    Click me
+</button>
+<script src="/coverage_fixture1.js">
+</script>
+<script src="/coverage_fixture2.js">
+</script>
+</body>
+</html>

--- a/tests/coverage_fixtures/coverage_fixture1.js
+++ b/tests/coverage_fixtures/coverage_fixture1.js
@@ -1,0 +1,8 @@
+window.onload = function() {
+    var loaded = true;
+};
+var button = document.getElementById("incrementor");
+button.onclick = function() {
+    var clicked = true;
+};
+

--- a/tests/coverage_fixtures/coverage_fixture2.js
+++ b/tests/coverage_fixtures/coverage_fixture2.js
@@ -1,0 +1,3 @@
+function thisIsNeverExecuted() {
+
+}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -35,6 +35,7 @@ impl Server {
         }
     }
 
+    #[allow(dead_code)]
     pub fn with_dumb_html(data: &'static str) -> Self {
         let responder = move |r: tiny_http::Request| {
             let response = tiny_http::Response::new(


### PR DESCRIPTION
Unlike Puppeteer (and related to this comment: https://github.com/atroche/rust-headless-chrome/issues/82#issuecomment-470167972) I'm not munging the data from Chrome into a friendlier format. We can always add helpers for that later if this causes confusion (or make it the default, to keep more in line with Puppeteer's API as opposed to the Chrome DevTools API).

The test is probably the best entry point for reading this PR, although on the whole I'm doing little more than wrapping raw CDTP methods.