### PR TITLE
Add more helper-methods on ElementQuad

### DIFF
--- a/src/browser/tab/element.rs
+++ b/src/browser/tab/element.rs
@@ -50,128 +50,99 @@ impl ElementQuad {
         self.width() / self.height()
     }
 
-    /// If the most bottom point of `self` is above the most top point of `other`
-    pub fn is_strictly_above(&self, other: &Self) -> bool {
+    /// The most left (smallest) x-coordinate
+    pub fn most_left(&self) -> f64 {
+        self.top_right
+            .x
+            .min(self.top_left.x)
+            .min(self.bottom_right.x)
+            .min(self.bottom_left.x)
+    }
+
+    /// The most right (largest) x-coordinate
+    pub fn most_right(&self) -> f64 {
+        self.top_right
+            .x
+            .max(self.top_left.x)
+            .max(self.bottom_right.x)
+            .max(self.bottom_left.x)
+    }
+
+    /// The most top (smallest) y-coordinate
+    pub fn most_top(&self) -> f64 {
+        self.top_right
+            .y
+            .min(self.top_left.y)
+            .min(self.bottom_right.y)
+            .min(self.bottom_left.y)
+    }
+
+    /// The most bottom (largest) y-coordinate
+    fn most_bottom(&self) -> f64 {
         self.top_right
             .y
             .max(self.top_left.y)
             .max(self.bottom_right.y)
             .max(self.bottom_left.y)
-            < other
-                .top_right
-                .y
-                .min(other.top_left.y)
-                .min(other.bottom_right.y)
-                .min(other.bottom_left.y)
+    }
+
+    /// If the most bottom point of `self` is above the most top point of `other`
+    pub fn strictly_above(&self, other: &Self) -> bool {
+        self.most_bottom() < other.most_top()
     }
 
     /// If the most bottom point of `self` is above or on the same line as the
     /// most top point of `other`
-    pub fn is_above(&self, other: &Self) -> bool {
-        self.top_right
-            .y
-            .max(self.top_left.y)
-            .max(self.bottom_right.y)
-            .max(self.bottom_left.y)
-            <= other
-                .top_right
-                .y
-                .min(other.top_left.y)
-                .min(other.bottom_right.y)
-                .min(other.bottom_left.y)
+    pub fn above(&self, other: &Self) -> bool {
+        self.most_bottom() <= other.most_top()
     }
 
     /// If the most top point of `self` is below the most bottom point of `other`
-    pub fn is_strictly_below(&self, other: &Self) -> bool {
-        self.top_right
-            .y
-            .min(self.top_left.y)
-            .min(self.bottom_right.y)
-            .min(self.bottom_left.y)
-            > other
-                .top_right
-                .y
-                .max(other.top_left.y)
-                .max(other.bottom_right.y)
-                .max(other.bottom_left.y)
+    pub fn strictly_below(&self, other: &Self) -> bool {
+        self.most_top() > other.most_bottom()
     }
 
     /// If the most top point of `self` is below or on the same line as the
     /// most bottom point of `other`
-    pub fn is_below(&self, other: &Self) -> bool {
-        self.top_right
-            .y
-            .min(self.top_left.y)
-            .min(self.bottom_right.y)
-            .min(self.bottom_left.y)
-            >= other
-                .top_right
-                .y
-                .max(other.top_left.y)
-                .max(other.bottom_right.y)
-                .max(other.bottom_left.y)
+    pub fn below(&self, other: &Self) -> bool {
+        self.most_top() >= other.most_bottom()
     }
 
     /// If the most right point of `self` is left of the most left point of `other`
-    pub fn is_strictly_left_of(&self, other: &Self) -> bool {
-        self.top_right
-            .x
-            .max(self.top_left.x)
-            .max(self.bottom_right.x)
-            .max(self.bottom_left.x)
-            < other
-                .top_right
-                .x
-                .min(other.top_left.x)
-                .min(other.bottom_right.x)
-                .min(other.bottom_left.x)
+    pub fn strictly_left_of(&self, other: &Self) -> bool {
+        self.most_right() < other.most_left()
     }
 
     /// If the most right point of `self` is left or on the same line as the
     /// most left point of `other`
-    pub fn is_left_of(&self, other: &Self) -> bool {
-        self.top_right
-            .x
-            .max(self.top_left.x)
-            .max(self.bottom_right.x)
-            .max(self.bottom_left.x)
-            <= other
-                .top_right
-                .x
-                .min(other.top_left.x)
-                .min(other.bottom_right.x)
-                .min(other.bottom_left.x)
+    pub fn left_of(&self, other: &Self) -> bool {
+        self.most_right() <= other.most_left()
     }
 
     /// If the most left point of `self` is right of the most right point of `other`
-    pub fn is_strictly_right_of(&self, other: &Self) -> bool {
-        self.top_right
-            .x
-            .min(self.top_left.x)
-            .min(self.bottom_right.x)
-            .min(self.bottom_left.x)
-            > other
-                .top_right
-                .x
-                .max(other.top_left.x)
-                .max(other.bottom_right.x)
-                .max(other.bottom_left.x)
+    pub fn strictly_right_of(&self, other: &Self) -> bool {
+        self.most_left() > other.most_right()
     }
 
     /// If the most left point of `self` is right or on the same line as the
     /// most right point of `other`
-    pub fn is_right_of(&self, other: &Self) -> bool {
-        self.top_right
-            .x
-            .min(self.top_left.x)
-            .min(self.bottom_right.x)
-            .min(self.bottom_left.x)
-            >= other
-                .top_right
-                .x
-                .max(other.top_left.x)
-                .max(other.bottom_right.x)
-                .max(other.bottom_left.x)
+    pub fn right_of(&self, other: &Self) -> bool {
+        self.most_left() >= other.most_right()
+    }
+
+    /// If `self` is within the left/right boundaries defined by `other`.
+    pub fn within_horizontal_bounds_of(&self, other: &Self) -> bool {
+        self.most_left() >= other.most_left() && self.most_right() <= other.most_right()
+    }
+
+    /// If `self` is within the top/bottom boundaries defined by `other`.
+    pub fn within_vertical_bounds_of(&self, other: &Self) -> bool {
+        self.most_top() >= other.most_top() && self.most_bottom() <= other.most_bottom()
+    }
+
+    /// If `self` is within the boundaries defined by `other`.
+    pub fn within_bounds_of(&self, other: &Self) -> bool {
+        self.within_horizontal_bounds_of(&other) && self.within_vertical_bounds_of(&other)
     }
 }
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -155,6 +155,7 @@ fn box_model_geometry() -> Result<(), failure::Error> {
     logging::enable_logging();
     let (_, browser, tab) = dumb_server(include_str!("simple.html"));
     let center = tab.wait_for_element("div#position-test")?.get_box_model()?;
+    let within = tab.wait_for_element("div#within")?.get_box_model()?;
     let above = tab
         .wait_for_element("div#strictly-above")?
         .get_box_model()?;
@@ -166,25 +167,32 @@ fn box_model_geometry() -> Result<(), failure::Error> {
         .wait_for_element("div#strictly-right")?
         .get_box_model()?;
 
-    assert!(above.content.is_strictly_above(&center.content));
-    assert!(above.content.is_above(&center.content));
-    assert!(above.margin.is_above(&center.content));
-    assert!(!above.margin.is_strictly_above(&center.content));
+    assert!(above.content.strictly_above(&center.content));
+    assert!(above.content.above(&center.content));
+    assert!(above.margin.above(&center.content));
+    assert!(!above.margin.strictly_above(&center.content));
+    assert!(above.content.within_horizontal_bounds_of(&center.content));
+    assert!(!above.content.within_vertical_bounds_of(&center.content));
 
-    assert!(below.content.is_strictly_below(&center.content));
-    assert!(below.content.is_below(&center.content));
-    assert!(below.margin.is_below(&center.content));
-    assert!(!below.margin.is_strictly_below(&center.content));
+    assert!(below.content.strictly_below(&center.content));
+    assert!(below.content.below(&center.content));
+    assert!(below.margin.below(&center.content));
+    assert!(!below.margin.strictly_below(&center.content));
 
-    assert!(left.content.is_strictly_left_of(&center.content));
-    assert!(left.content.is_left_of(&center.content));
-    assert!(left.margin.is_left_of(&center.content));
-    assert!(!left.margin.is_strictly_left_of(&center.content));
+    assert!(left.content.strictly_left_of(&center.content));
+    assert!(left.content.left_of(&center.content));
+    assert!(left.margin.left_of(&center.content));
+    assert!(!left.margin.strictly_left_of(&center.content));
+    assert!(!left.content.within_horizontal_bounds_of(&center.content));
+    assert!(left.content.within_vertical_bounds_of(&center.content));
 
-    assert!(right.content.is_strictly_right_of(&center.content));
-    assert!(right.content.is_right_of(&center.content));
-    assert!(right.margin.is_right_of(&center.content));
-    assert!(!right.margin.is_strictly_right_of(&center.content));
+    assert!(right.content.strictly_right_of(&center.content));
+    assert!(right.content.right_of(&center.content));
+    assert!(right.margin.right_of(&center.content));
+    assert!(!right.margin.strictly_right_of(&center.content));
+
+    assert!(within.content.within_bounds_of(&center.content));
+    assert!(!center.content.within_bounds_of(&within.content));
 
     Ok(())
 }


### PR DESCRIPTION
This adds more helper functions to `ElementQuad` that I'm using in tests to the tune of `assert!(foo_node.content.within_horizontal_bounds_of(&bar_node.margin))`