### PR TITLE
Add find / wait for elements methods

### DIFF
--- a/src/browser/tab/element.rs
+++ b/src/browser/tab/element.rs
@@ -3,7 +3,6 @@ use log::*;
 
 use super::point::Point;
 use crate::protocol::dom;
-use crate::protocol::dom::NodeId;
 use crate::protocol::page;
 use crate::protocol::runtime;
 use std::collections::HashMap;

--- a/src/browser/tab/element.rs
+++ b/src/browser/tab/element.rs
@@ -3,6 +3,7 @@ use log::*;
 
 use super::point::Point;
 use crate::protocol::dom;
+use crate::protocol::dom::NodeId;
 use crate::protocol::page;
 use crate::protocol::runtime;
 use std::collections::HashMap;
@@ -210,6 +211,40 @@ pub struct Element<'a> {
 }
 
 impl<'a> Element<'a> {
+    /// Using a 'node_id', of the type returned by QuerySelector and QuerySelectorAll, this finds
+    /// the 'backend_node_id' and 'remote_object_id' which are stable identifiers, unlike node_id.
+    /// We use these two when making various calls to the API because of that.
+    pub fn new(
+        parent: &'a super::Tab,
+        node_id: dom::NodeId,
+        found_via_selector: &'a str,
+    ) -> Result<Self, Error> {
+        if node_id == 0 {
+            return Err(super::NoElementFound {
+                selector: found_via_selector.to_string(),
+            }
+                .into());
+        }
+
+        let backend_node_id = parent.describe_node(node_id)?.backend_node_id;
+
+        let remote_object_id = {
+            let object = parent
+                .call_method(dom::methods::ResolveNode {
+                    backend_node_id: Some(backend_node_id),
+                })?
+                .object;
+            object.object_id.expect("couldn't find object ID")
+        };
+
+        Ok(Element {
+            remote_object_id,
+            backend_node_id,
+            parent,
+            found_via_selector,
+        })
+    }
+
     pub fn click(&self) -> Result<&Self, Error> {
         debug!("Clicking element found via {}", self.found_via_selector);
 

--- a/src/browser/tab/element.rs
+++ b/src/browser/tab/element.rs
@@ -223,7 +223,7 @@ impl<'a> Element<'a> {
             return Err(super::NoElementFound {
                 selector: found_via_selector.to_string(),
             }
-                .into());
+            .into());
         }
 
         let backend_node_id = parent.describe_node(node_id)?.backend_node_id;

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -18,6 +18,7 @@ use crate::protocol::{dom, input, page, profiler, target};
 use crate::{protocol, util};
 
 use super::transport::SessionId;
+use crate::protocol::dom::Node;
 
 pub mod element;
 mod keys;
@@ -185,16 +186,29 @@ impl<'a> Tab {
             .map_err(|e| e.into())
     }
 
+    pub fn wait_for_elements(&'a self, selector: &'a str) -> Result<Vec<Element<'a>>, Error> {
+        debug!("Waiting for element with selector: {}", selector);
+        util::Wait::default()
+            .until(|| {
+                if let Ok(elements) = self.find_elements(selector) {
+                    if elements.iter().all(|element| element.get_midpoint().is_ok()) {
+                        Some(elements)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .map_err(|e| e.into())
+    }
+
     pub fn find_element(&'a self, selector: &'a str) -> Result<Element<'a>, Error> {
         trace!("Looking up element via selector: {}", selector);
 
         let node_id = {
             let root_node_id = self
-                .call_method(dom::methods::GetDocument {
-                    depth: Some(0),
-                    pierce: Some(false),
-                })?
-                .root
+                .get_document()?
                 .node_id;
 
             self.call_method(dom::methods::QuerySelector {
@@ -204,29 +218,46 @@ impl<'a> Tab {
             .node_id
         };
 
-        if node_id == 0 {
+
+        Element::new(&self, node_id, selector)
+    }
+
+    pub fn get_document(&self) -> Result<Node, Error> {
+        Ok(self
+            .call_method(dom::methods::GetDocument {
+                depth: Some(0),
+                pierce: Some(false),
+            })?
+            .root)
+    }
+
+    pub fn find_elements(&'a self, selector: &'a str) -> Result<Vec<Element<'a>>, Error> {
+        trace!("Looking up elements via selector: {}", selector);
+
+        let node_ids = {
+            let root_node_id = self.get_document()?.node_id;
+
+            self.call_method(dom::methods::QuerySelectorAll {
+                node_id: root_node_id,
+                selector,
+            })?
+            .node_ids
+        };
+
+        if node_ids.is_empty() {
             return Err(NoElementFound {
                 selector: selector.to_string(),
             }
             .into());
         }
 
-        let backend_node_id = self.describe_node(node_id)?.backend_node_id;
+        let mut elements = vec![];
 
-        let remote_object_id = {
-            let object = self
-                .call_method(dom::methods::ResolveNode {
-                    backend_node_id: Some(backend_node_id),
-                })?
-                .object;
-            object.object_id.expect("couldn't find object ID")
-        };
-        Ok(Element {
-            remote_object_id,
-            backend_node_id,
-            parent: &self,
-            found_via_selector: selector,
-        })
+        for node_id in node_ids.iter() {
+            elements.push(Element::new(&self, *node_id, selector)?)
+        }
+
+        Ok(elements)
     }
 
     pub fn describe_node(&self, node_id: dom::NodeId) -> Result<dom::Node, Error> {

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -254,7 +254,7 @@ impl<'a> Tab {
 
         let mut elements = vec![];
 
-        for node_id in node_ids.iter() {
+        for node_id in &node_ids {
             elements.push(Element::new(&self, *node_id, selector)?)
         }
 

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -19,6 +19,7 @@ use crate::{protocol, util};
 
 use super::transport::SessionId;
 use crate::protocol::dom::Node;
+use std::time::Duration;
 
 pub mod element;
 mod keys;
@@ -188,7 +189,7 @@ impl<'a> Tab {
 
     pub fn wait_for_elements(&'a self, selector: &'a str) -> Result<Vec<Element<'a>>, Error> {
         debug!("Waiting for element with selector: {}", selector);
-        util::Wait::default()
+        util::Wait::with_timeout(Duration::from_secs(15))
             .until(|| {
                 if let Ok(elements) = self.find_elements(selector) {
                     if elements.iter().all(|element| element.get_midpoint().is_ok()) {

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -192,7 +192,10 @@ impl<'a> Tab {
         util::Wait::with_timeout(Duration::from_secs(15))
             .until(|| {
                 if let Ok(elements) = self.find_elements(selector) {
-                    if elements.iter().all(|element| element.get_midpoint().is_ok()) {
+                    if elements
+                        .iter()
+                        .all(|element| element.get_midpoint().is_ok())
+                    {
                         Some(elements)
                     } else {
                         None
@@ -208,9 +211,7 @@ impl<'a> Tab {
         trace!("Looking up element via selector: {}", selector);
 
         let node_id = {
-            let root_node_id = self
-                .get_document()?
-                .node_id;
+            let root_node_id = self.get_document()?.node_id;
 
             self.call_method(dom::methods::QuerySelector {
                 node_id: root_node_id,
@@ -218,7 +219,6 @@ impl<'a> Tab {
             })?
             .node_id
         };
-
 
         Element::new(&self, node_id, selector)
     }

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -122,8 +122,14 @@ impl<'a> Tab {
     where
         C: protocol::Method + serde::Serialize + std::fmt::Debug,
     {
-        self.transport
-            .call_method_on_target(self.session_id.clone(), method)
+        debug!("Calling method: {:?}", method);
+        let result = self
+            .transport
+            .call_method_on_target(self.session_id.clone(), method);
+        let mut result_string = format!("{:?}", result);
+        result_string.truncate(70);
+        debug!("Got result: {:?}", result_string);
+        result
     }
 
     pub fn wait_until_navigated(&self) -> Result<&Self, Error> {
@@ -175,11 +181,7 @@ impl<'a> Tab {
         util::Wait::with_timeout(timeout)
             .until(|| {
                 if let Ok(element) = self.find_element(selector) {
-                    if element.get_midpoint().is_ok() {
-                        Some(element)
-                    } else {
-                        None
-                    }
+                    Some(element)
                 } else {
                     None
                 }
@@ -192,14 +194,7 @@ impl<'a> Tab {
         util::Wait::with_timeout(Duration::from_secs(15))
             .until(|| {
                 if let Ok(elements) = self.find_elements(selector) {
-                    if elements
-                        .iter()
-                        .all(|element| element.get_midpoint().is_ok())
-                    {
-                        Some(elements)
-                    } else {
-                        None
-                    }
+                    Some(elements)
                 } else {
                     None
                 }

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -142,7 +142,8 @@ impl Transport {
         }
 
         trace!("waiting for response from call registry");
-        let response_result = util::Wait::default().until(|| response_rx.try_recv().ok());
+        let response_result =
+            util::Wait::with_sleep(Duration::from_millis(5)).until(|| response_rx.try_recv().ok());
         protocol::parse_response::<C::ReturnObject>((response_result?)?)
     }
 

--- a/src/protocol/dom.rs
+++ b/src/protocol/dom.rs
@@ -219,6 +219,22 @@ pub mod methods {
         type ReturnObject = QuerySelectorReturnObject;
     }
 
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct QuerySelectorAll<'a> {
+        pub node_id: super::NodeId,
+        pub selector: &'a str,
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct QuerySelectorAllReturnObject {
+        pub node_ids: Vec<super::NodeId>,
+    }
+    impl<'a> Method for QuerySelectorAll<'a> {
+        const NAME: &'static str = "DOM.querySelectorAll";
+        type ReturnObject = QuerySelectorAllReturnObject;
+    }
+
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct RemoteObject {

--- a/src/util.rs
+++ b/src/util.rs
@@ -34,6 +34,13 @@ impl Wait {
         }
     }
 
+    pub fn with_sleep(sleep: Duration) -> Self {
+        Self {
+            sleep,
+            ..Self::default()
+        }
+    }
+
     pub fn forever() -> Self {
         Self {
             timeout: Duration::from_secs(u64::max_value()),

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -229,3 +229,12 @@ fn reload() -> Result<(), failure::Error> {
     // TODO test effect of scriptEvaluateOnLoad
     Ok(())
 }
+
+#[test]
+fn find_elements() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let (server, browser, tab) = dumb_server(include_str!("simple.html"));
+    let divs = tab.wait_for_elements("div")?;
+    assert_eq!(8, divs.len());
+    Ok(())
+}


### PR DESCRIPTION
Still unsure about the whole `wait` vs `find` part of the API, and also the necessity of the "custom timeout" version, and also the `found_via_selector` field, but those can wait for another time. 