### PR TITLE
Add fetcher as a default feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: rust
 
 rust:
-    - stable
-    - nightly
+  - stable
+  - nightly
 
 addons:
   chrome: stable
   apt:
     packages:
       - libnss3
-env:
-  - IN_CI=true
 
 os:
   - linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,10 @@ toml = "0.4"
 chrono = "0.4"
 base64 = "0.10"
 derive_builder = "0.7.1"
-reqwest = "0.9"
-directories = "1.0"
-indicatif = "0.11"
-zip = "0.5"
 which = "2.0"
+reqwest = { version = "0.9", optional = true }
+directories = { version = "1.0", optional = true }
+zip = { version = "0.5", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6"
@@ -43,4 +42,5 @@ name = "headless_chrome"
 path = "src/lib.rs"
 
 [features]
+default = [ "reqwest", "directories", "zip" ]
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,6 @@ name = "headless_chrome"
 path = "src/lib.rs"
 
 [features]
-default = [ "reqwest", "directories", "zip" ]
+default = [ "fetch" ]
+fetch = ["reqwest", "directories", "zip"]
 nightly = []

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ If you're looking to do general browser testing or scraping (rather than anythin
 
 If you get errors related to timeouts, you likely need to enable sandboxing either in the kernel or as a setuid sandbox. Puppeteer has some information about how to do that [here](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md)
 
+By default, `headless_chrome` will download a compatible version of chrome to `XDG_DATA_HOME` (or equivalent on Windows/Mac). This behaviour can be optionally turned off, and you can use the system version of chrome (assuming you have chrome installed) by disabling the default feature in your `Cargo.toml`:
+
+```
+[dependencies.headless_chrome]
+default-features = false
+```
+
 ## Missing features
 
 - Frame / iframe support

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you get errors related to timeouts, you likely need to enable sandboxing eith
 
 By default, `headless_chrome` will download a compatible version of chrome to `XDG_DATA_HOME` (or equivalent on Windows/Mac). This behaviour can be optionally turned off, and you can use the system version of chrome (assuming you have chrome installed) by disabling the default feature in your `Cargo.toml`:
 
-```
+```toml
 [dependencies.headless_chrome]
 default-features = false
 ```

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -22,6 +22,7 @@ pub use tab::Tab;
 use transport::Transport;
 
 pub mod context;
+#[cfg(feature = "default")]
 mod fetcher;
 mod process;
 pub mod tab;
@@ -104,7 +105,7 @@ impl Browser {
     pub fn wait_for_initial_tab(&self) -> Result<Arc<Tab>, Error> {
         util::Wait::with_timeout(Duration::from_secs(10))
             .until(|| self.tabs.lock().unwrap().first().map(|tab| Arc::clone(tab)))
-            .map_err(|e| e.into())
+            .map_err(Into::into)
     }
 
     /// Create a new tab and return a handle to it.
@@ -167,7 +168,7 @@ impl Browser {
                     .find(|tab| *tab.get_target_id() == target_id)
                     .map(|tab_ref| Arc::clone(tab_ref))
             })
-            .map_err(|e| e.into())
+            .map_err(Into::into)
     }
 
     /// Creates the equivalent of a new incognito window, AKA a browser context

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -22,7 +22,7 @@ pub use tab::Tab;
 use transport::Transport;
 
 pub mod context;
-#[cfg(feature = "default")]
+#[cfg(feature = "fetch")]
 mod fetcher;
 mod process;
 pub mod tab;

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -16,9 +16,9 @@ use std::{
 #[cfg(windows)]
 use winreg::{enums::HKEY_LOCAL_MACHINE, RegKey};
 
-#[cfg(feature = "default")]
+#[cfg(feature = "fetch")]
 use super::fetcher::{self, Fetcher};
-#[cfg(not(feature = "default"))]
+#[cfg(not(feature = "fetch"))]
 use crate::browser::default_executable;
 
 use crate::util;
@@ -87,12 +87,12 @@ pub struct LaunchOptions<'a> {
     /// The revision of chrome to use
     ///
     /// By default, we'll use a revision guaranteed to work with our API.
-    #[cfg(feature = "default")]
+    #[cfg(feature = "fetch")]
     #[builder(default = "self.default_revision()")]
     revision: &'static str,
 }
 
-#[cfg(feature = "default")]
+#[cfg(feature = "fetch")]
 impl<'a> LaunchOptionsBuilder<'a> {
     fn default_revision(&self) -> &'static str {
         fetcher::CUR_REV
@@ -102,12 +102,12 @@ impl<'a> LaunchOptionsBuilder<'a> {
 impl Process {
     pub fn new(mut launch_options: LaunchOptions) -> Result<Self, Error> {
         if launch_options.path.is_none() {
-            #[cfg(feature = "default")]
+            #[cfg(feature = "fetch")]
             {
                 let fetch = Fetcher::new(launch_options.revision)?;
                 launch_options.path = Some(fetch.run()?);
             }
-            #[cfg(not(feature = "default"))]
+            #[cfg(not(feature = "fetch"))]
             {
                 launch_options.path = Some(default_executable().map_err(|e| format_err!("{}", e))?);
             }

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -198,7 +198,7 @@ impl<'a> Tab {
                     None
                 }
             })
-            .map_err(|e| e.into())
+            .map_err(Into::into)
     }
 
     pub fn wait_for_elements(&self, selector: &str) -> Result<Vec<Element<'_>>, Error> {
@@ -211,7 +211,7 @@ impl<'a> Tab {
                     None
                 }
             })
-            .map_err(|e| e.into())
+            .map_err(Into::into)
     }
 
     pub fn find_element(&self, selector: &str) -> Result<Element<'_>, Error> {


### PR DESCRIPTION
I killed the progressbar and removed `indicatif`

`reqwest`, `zip`, and `directories` are optional, but default. so @lukaslueg you should be fine to run w/o bringing in any tokio deps by using:

```
[dependencies.headless_chrome]
default-features = false
``` 

Come to think of it, I need to add that to the readme