### PR TITLE
Replace reqwest with ureq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tempfile = "3"
 base64 = "0.10"
 derive_builder = "0.7.1"
 which = "2.0"
-reqwest = { version = "0.9", optional = true }
+ureq = { version = "0.9", optional = true }
 directories = { version = "1.0", optional = true }
 zip = { version = "0.5", optional = true }
 
@@ -43,5 +43,5 @@ path = "src/lib.rs"
 
 [features]
 default = [ "fetch" ]
-fetch = [ "reqwest", "directories", "zip" ]
+fetch = [ "ureq", "directories", "zip" ]
 nightly = []


### PR DESCRIPTION
#93 let's close this

This came up a few times; reqwest brings in a huge transitive dependency. It was suggested to replace with `ureq`. It looks cross platform? I don't have any environments other than linux to test.

If someone could try on mac & windows that'd be nice.

Also, prints DL size in MiB now instead of bytes