### PR TITLE
Add window size option

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -123,7 +123,11 @@ impl Browser {
     }
 
     pub fn get_process_id(&self) -> Option<u32> {
-        self.process.as_ref().map(|process| process.get_id())
+        if let Some(process) = &self.process {
+            Some(process.get_id())
+        } else {
+            None
+        }
     }
 
     /// The tabs are behind an `Arc` and `Mutex` because they're accessible from multiple threads

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -64,8 +64,6 @@ pub struct LaunchOptions<'a> {
     #[builder(default = "true")]
     headless: bool,
     /// Launch the browser with a specific window width and height.
-    ///
-    /// If unspecified, the window size will be set to 1920 x 1080.
     #[builder(default = "None")]
     window_size: Option<(u32, u32)>,
     /// Launch the browser with a specific debugging port.
@@ -165,13 +163,11 @@ impl Process {
         };
         let port_option = format!("--remote-debugging-port={}", debug_port);
 
-        let window_size = if let Some((width, height)) = launch_options.window_size {
-            (width, height)
+        let window_size_option = if let Some((width, height)) = launch_options.window_size {
+            format!("--window-size={},{}", width, height)
         } else {
-            (1920, 1080)
+            String::from("")
         };
-
-        let window_size_option = format!("--window-size={},{}", window_size.0, window_size.1);
 
         // NOTE: picking random data dir so that each a new browser instance is launched
         // (see man google-chrome)

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -68,6 +68,10 @@ pub struct LaunchOptions<'a> {
     #[builder(default = "None")]
     port: Option<u16>,
 
+    /// Launch the browser with a specific window width and height.
+    #[builder(default = "None")]
+    window_size: Option<(u32, u32)>,
+
     /// Path for Chrome or Chromium.
     ///
     /// If unspecified, the create will try to automatically detect a suitable binary.
@@ -180,6 +184,15 @@ impl Process {
 
         if launch_options.headless {
             args.extend(&["--headless"]);
+        }
+
+        if let Some((width, height)) = launch_options.window_size {
+            args.extend(&[unsafe {
+                std::mem::transmute::<Box<str>, &'static str>(std::boxed::Box::from(format!(
+                    "--window-size={},{}",
+                    width, height
+                )))
+            }]);
         }
 
         let extension_args: Vec<String> = launch_options

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -64,6 +64,8 @@ pub struct LaunchOptions<'a> {
     #[builder(default = "true")]
     headless: bool,
     /// Launch the browser with a specific window width and height.
+    /// 
+    /// If unspecified, the window size will be set to 1920 x 1080.
     #[builder(default = "None")]
     window_size: Option<(u32, u32)>,
     /// Launch the browser with a specific debugging port.

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -64,7 +64,7 @@ pub struct LaunchOptions<'a> {
     #[builder(default = "true")]
     headless: bool,
     /// Launch the browser with a specific window width and height.
-    /// 
+    ///
     /// If unspecified, the window size will be set to 1920 x 1080.
     #[builder(default = "None")]
     window_size: Option<(u32, u32)>,

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -180,10 +180,10 @@ impl Process {
 
         let mut args = vec![
             port_option.as_str(),
+            window_size_option.as_str(),
             "--verbose",
             "--no-first-run",
             data_dir_option.as_str(),
-            window_size_option.as_str(),
         ];
 
         if launch_options.headless {

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -68,10 +68,6 @@ pub struct LaunchOptions<'a> {
     #[builder(default = "None")]
     port: Option<u16>,
 
-    /// Launch the browser with a specific window width and height.
-    #[builder(default = "None")]
-    window_size: Option<(u32, u32)>,
-
     /// Path for Chrome or Chromium.
     ///
     /// If unspecified, the create will try to automatically detect a suitable binary.
@@ -184,15 +180,6 @@ impl Process {
 
         if launch_options.headless {
             args.extend(&["--headless"]);
-        }
-
-        if let Some((width, height)) = launch_options.window_size {
-            args.extend(&[unsafe {
-                std::mem::transmute::<Box<str>, &'static str>(std::boxed::Box::from(format!(
-                    "--window-size={},{}",
-                    width, height
-                )))
-            }]);
         }
 
         let extension_args: Vec<String> = launch_options

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -185,7 +185,7 @@ impl Process {
             "--verbose",
             "--no-first-run",
             data_dir_option.as_str(),
-            window_size_option.as_str()
+            window_size_option.as_str(),
         ];
 
         if launch_options.headless {

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -184,7 +184,7 @@ impl Process {
             "--no-first-run",
             data_dir_option.as_str(),
         ];
-        
+
         if !window_size_option.is_empty() {
             args.extend(&[window_size_option.as_str()]);
         }

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -180,11 +180,14 @@ impl Process {
 
         let mut args = vec![
             port_option.as_str(),
-            window_size_option.as_str(),
             "--verbose",
             "--no-first-run",
             data_dir_option.as_str(),
         ];
+        
+        if !window_size_option.is_empty() {
+            args.extend(&[window_size_option.as_str()]);
+        }
 
         if launch_options.headless {
             args.extend(&["--headless"]);

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -63,7 +63,9 @@ pub struct LaunchOptions<'a> {
     /// Determintes whether to run headless version of the browser. Defaults to true.
     #[builder(default = "true")]
     headless: bool,
-
+    /// Launch the browser with a specific window width and height.
+    #[builder(default = "None")]
+    window_size: Option<(u32, u32)>,
     /// Launch the browser with a specific debugging port.
     #[builder(default = "None")]
     port: Option<u16>,
@@ -161,6 +163,14 @@ impl Process {
         };
         let port_option = format!("--remote-debugging-port={}", debug_port);
 
+        let window_size = if let Some((width, height)) = launch_options.window_size {
+            (width, height)
+        } else {
+            (1920, 1080)
+        };
+
+        let window_size_option = format!("--window-size={},{}", window_size.0, window_size.1);
+
         // NOTE: picking random data dir so that each a new browser instance is launched
         // (see man google-chrome)
         let user_data_dir = ::tempfile::Builder::new()
@@ -175,7 +185,7 @@ impl Process {
             "--verbose",
             "--no-first-run",
             data_dir_option.as_str(),
-            //            "--window-size=1920,1080"
+            window_size_option.as_str()
         ];
 
         if launch_options.headless {


### PR DESCRIPTION
This adds the `--window-size` option to the argument list. [Two](https://travis-ci.com/iwatakeshi/rust-headless-chrome/builds/109332816) of the Travis builds [are failing](https://travis-ci.com/iwatakeshi/rust-headless-chrome/jobs/195028831#L733) but it seems irrelevant to the changes I made. If this is something I need to take care of, please let me know.