### PR TITLE
Add chrome paths

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -348,13 +348,11 @@ impl Drop for Browser {
 /// Returns the path to Chrome's executable.
 /// 
 /// If the `CHROME` environment variable is set, `default_executable` will
-/// use it as the default path. Otherwise, the following filenames will searched:
-/// 
-/// * google-chrome-stable
-/// * chromium
-/// * chromium-browser
-/// * chrome
-/// * chrome-browser
+/// use it as the default path. Otherwise, the filenames `google-chrome-stable`
+/// `chromium`, `chromium-browser`, `chrome` and `chrome-browser` are
+/// searched for in standard places. If that fails, 
+/// `/Applications/Google Chrome.app/...` (on MacOS) or the registry (on Windows)
+/// is consulted. If all of the above fail, an error is returned.
 pub fn default_executable() -> Result<std::path::PathBuf, String> {
     if let Ok(path) = std::env::var("CHROME") {
         if std::path::Path::new(&path).exists() {

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -345,10 +345,17 @@ impl Drop for Browser {
     }
 }
 
+/// Returns the path to Chrome's executable.
+/// 
+/// If the `CHROME` environment variable is set, `default_executable` will
+/// use it as the default path. Otherwise, the following filenames will searched:
+/// 
+/// * google-chrome-stable
+/// * chromium
+/// * chromium-browser
+/// * chrome
+/// * chrome-browser
 pub fn default_executable() -> Result<std::path::PathBuf, String> {
-    // TODO Look at $BROWSER and if it points to a chrome binary
-    // $BROWSER may also provide default arguments, which we may
-    // or may not override later on.
     if let Ok(path) = std::env::var("CHROME") {
         if std::path::Path::new(&path).exists() {
             return Ok(path.into());

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -349,12 +349,12 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
     // TODO Look at $BROWSER and if it points to a chrome binary
     // $BROWSER may also provide default arguments, which we may
     // or may not override later on.
-    if let Ok(path) std::env::var("CHROME") {
+    if let Ok(path) = std::env::var("CHROME") {
         if std::path::Path::new(path).exists() {
             return Ok(path);
         }
     }
-    
+
     for app in &[
         "google-chrome-stable",
         "chromium",

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -350,8 +350,8 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
     // $BROWSER may also provide default arguments, which we may
     // or may not override later on.
     if let Ok(path) = std::env::var("CHROME") {
-        if std::path::Path::new(path).exists() {
-            return Ok(path);
+        if std::path::Path::new(&path).exists() {
+            return Ok(path.into());
         }
     }
 

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -354,7 +354,7 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
             return Ok(path);
         }
     }
-    
+
     for app in &[
         "google-chrome-stable",
         "chromium",

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -349,12 +349,12 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
     // TODO Look at $BROWSER and if it points to a chrome binary
     // $BROWSER may also provide default arguments, which we may
     // or may not override later on.
-    if let Ok(path) = std::env::var("CHROME") {
+    if let Ok(path) std::env::var("CHROME") {
         if std::path::Path::new(path).exists() {
             return Ok(path);
         }
     }
-
+    
     for app in &[
         "google-chrome-stable",
         "chromium",

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -346,11 +346,11 @@ impl Drop for Browser {
 }
 
 /// Returns the path to Chrome's executable.
-/// 
+///
 /// If the `CHROME` environment variable is set, `default_executable` will
 /// use it as the default path. Otherwise, the filenames `google-chrome-stable`
 /// `chromium`, `chromium-browser`, `chrome` and `chrome-browser` are
-/// searched for in standard places. If that fails, 
+/// searched for in standard places. If that fails,
 /// `/Applications/Google Chrome.app/...` (on MacOS) or the registry (on Windows)
 /// is consulted. If all of the above fail, an error is returned.
 pub fn default_executable() -> Result<std::path::PathBuf, String> {

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -349,7 +349,7 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
     // TODO Look at $BROWSER and if it points to a chrome binary
     // $BROWSER may also provide default arguments, which we may
     // or may not override later on.
-    if let Ok(path) std::env::var("CHROME") {
+    if let Ok(path) = std::env::var("CHROME") {
         if std::path::Path::new(path).exists() {
             return Ok(path);
         }

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -349,8 +349,19 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
     // TODO Look at $BROWSER and if it points to a chrome binary
     // $BROWSER may also provide default arguments, which we may
     // or may not override later on.
-
-    for app in &["google-chrome-stable", "chromium"] {
+    if let Ok(path) std::env::var("CHROME") {
+        if std::path::Path::new(path).exists() {
+            return Ok(path);
+        }
+    }
+    
+    for app in &[
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+        "chrome",
+        "chrome-browser",
+    ] {
         if let Ok(path) = which(app) {
             return Ok(path);
         }


### PR DESCRIPTION
This adds additional paths to `default_executable()`. It also adds a check for an environment variable that may contain a path to the executable. 

I wasn't sure if `$CHROME` would be a good variable. I thought `$BROWSER` was too generic and may imply that Firefox or another browser can be accepted. If you like me to change it to `$BROWSER`, please let me know. Thanks.