### PR TITLE
Fix stalled wait-for-element calls

### DIFF
--- a/src/browser/tab/element.rs
+++ b/src/browser/tab/element.rs
@@ -2,6 +2,7 @@ use failure::{Error, Fail};
 use log::*;
 
 use super::point::Point;
+use crate::browser::tab::NoElementFound;
 use crate::protocol::dom;
 use crate::protocol::page;
 use crate::protocol::runtime;
@@ -228,10 +229,13 @@ impl<'a> Element<'a> {
     /// We use these two when making various calls to the API because of that.
     pub fn new(parent: &'a super::Tab, node_id: dom::NodeId) -> Result<Self, Error> {
         if node_id == 0 {
-            return Err(super::NoElementFound {}.into());
+            return Err(NoElementFound {}.into());
         }
 
-        let backend_node_id = parent.describe_node(node_id)?.backend_node_id;
+        let backend_node_id = parent
+            .describe_node(node_id)
+            .map_err(NoElementFound::map)?
+            .backend_node_id;
 
         let remote_object_id = {
             let object = parent

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -251,27 +251,13 @@ impl<'a> Tab {
     ) -> Result<Element<'_>, Error> {
         debug!("Waiting for element with selector: {}", selector);
         util::Wait::with_timeout(timeout)
-            .until(|| {
-                if let Ok(element) = self.find_element(selector) {
-                    Some(element)
-                } else {
-                    None
-                }
-            })
-            .map_err(Into::into)
+            .strict_until(|| self.find_element(selector), Error::downcast::<NoElementFound>)
     }
 
     pub fn wait_for_elements(&self, selector: &str) -> Result<Vec<Element<'_>>, Error> {
         debug!("Waiting for element with selector: {}", selector);
         util::Wait::with_timeout(Duration::from_secs(3))
-            .until(|| {
-                if let Ok(elements) = self.find_elements(selector) {
-                    Some(elements)
-                } else {
-                    None
-                }
-            })
-            .map_err(Into::into)
+            .strict_until(|| self.find_elements(selector), Error::downcast::<NoElementFound>)
     }
 
     pub fn find_element(&self, selector: &str) -> Result<Element<'_>, Error> {

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -250,14 +250,18 @@ impl<'a> Tab {
         timeout: std::time::Duration,
     ) -> Result<Element<'_>, Error> {
         debug!("Waiting for element with selector: {}", selector);
-        util::Wait::with_timeout(timeout)
-            .strict_until(|| self.find_element(selector), Error::downcast::<NoElementFound>)
+        util::Wait::with_timeout(timeout).strict_until(
+            || self.find_element(selector),
+            Error::downcast::<NoElementFound>,
+        )
     }
 
     pub fn wait_for_elements(&self, selector: &str) -> Result<Vec<Element<'_>>, Error> {
         debug!("Waiting for element with selector: {}", selector);
-        util::Wait::with_timeout(Duration::from_secs(3))
-            .strict_until(|| self.find_elements(selector), Error::downcast::<NoElementFound>)
+        util::Wait::with_timeout(Duration::from_secs(3)).strict_until(
+            || self.find_elements(selector),
+            Error::downcast::<NoElementFound>,
+        )
     }
 
     pub fn find_element(&self, selector: &str) -> Result<Element<'_>, Error> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-use crate::browser::tab::NoElementFound;
 use failure::{Error, Fail};
 use std::thread::sleep;
 use std::time::{Duration, Instant};


### PR DESCRIPTION
There is an odd issue with `wait_for_element` and `wait_for_elements` methods:

If an unexpected error occurs while you wait for some element (for example the browser gets closed / killed) you would expect that the blocking call to `wait_for_element` will fail immediately and provide a meaningful error (for example `RemoteError { code: -32602, message: "No session with given id" }`).

Instead what happens is that you keep on waiting for your call to finish and when it finally does - you get the standard `Timeout` error so you can't respond to the actual problem at hand.

This PR addresses the issue above, by implementing a stricter until method that can explicitly allow certain errors while failing and reporting the rest.