### PR TITLE
Add response handling callback for tabs.

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -201,9 +201,13 @@ impl Browser {
         util::Wait::with_timeout(Duration::from_secs(20))
             .until(|| {
                 let tabs = self.tabs.lock().unwrap();
-                tabs.iter()
-                    .find(|tab| *tab.get_target_id() == target_id)
-                    .map(|tab_ref| Arc::clone(tab_ref))
+                tabs.iter().find_map(|tab| {
+                    if *tab.get_target_id() == target_id {
+                        Some(tab.clone())
+                    } else {
+                        None
+                    }
+                })
             })
             .map_err(Into::into)
     }

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -214,18 +214,15 @@ impl<'a> Tab {
                         }
                     }
                     Event::ResponseReceived(ev) => {
-                        match response_handler_mutex.lock().unwrap().as_ref() {
-                            Some(handler) => {
-                                let request_id = ev.params.request_id.clone();
-                                let retrieve_body = || {
-                                    let method = network::methods::GetResponseBody {
-                                        request_id: &request_id,
-                                    };
-                                    transport.call_method_on_target(session_id.clone(), method)
+                        if let Some(handler) = response_handler_mutex.lock().unwrap().as_ref() {
+                            let request_id = ev.params.request_id.clone();
+                            let retrieve_body = || {
+                                let method = network::methods::GetResponseBody {
+                                    request_id: &request_id,
                                 };
-                                handler(ev.params, &retrieve_body);
-                            }
-                            None => {}
+                                transport.call_method_on_target(session_id.clone(), method)
+                            };
+                            handler(ev.params, &retrieve_body);
                         }
                     }
                     _ => {

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -272,10 +272,10 @@ impl Transport {
                                     let session_id = target_message_event.params.session_id.into();
                                     let raw_message = target_message_event.params.message;
 
-                                    if let Ok(target_message) =
-                                        protocol::parse_raw_message(&raw_message)
-                                    {
-                                        match target_message {
+                                    let msg_res = protocol::parse_raw_message(&raw_message);
+
+                                    match msg_res {
+                                        Ok(target_message) => match target_message {
                                             Message::Event(target_event) => {
                                                 if let Some(tx) = listeners
                                                     .lock()
@@ -295,12 +295,14 @@ impl Transport {
                                                 }
                                             }
                                             Message::ConnectionShutdown => {}
+                                        },
+                                        Err(e) => {
+                                            trace!(
+                                                "Message from target isn't recognised: {:?} - {}",
+                                                &raw_message,
+                                                e,
+                                            );
                                         }
-                                    } else {
-                                        trace!(
-                                            "Message from target isn't recognised: {:?}",
-                                            &raw_message
-                                        );
                                     }
                                 }
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -107,6 +107,8 @@ pub enum Event {
     Lifecycle(page::events::LifecycleEvent),
     #[serde(rename = "Network.requestIntercepted")]
     RequestIntercepted(network::events::RequestInterceptedEvent),
+    #[serde(rename = "Network.responseReceived")]
+    ResponseReceived(network::events::ResponseReceivedEvent),
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/protocol/network.rs
+++ b/src/protocol/network.rs
@@ -21,6 +21,32 @@ pub struct Request {
     pub is_link_preload: Option<bool>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Response {
+    pub url: String,
+    pub status: u32,
+    pub status_text: String,
+    pub headers: Headers,
+    pub headers_text: Option<String>,
+    pub mime_type: String,
+    pub request_headers: Option<Headers>,
+    pub request_headers_text: Option<String>,
+    pub connection_reused: bool,
+    pub connection_id: u64,
+    #[serde(rename = "remoteIPAddress")]
+    pub remote_ip_address: Option<String>,
+    pub remote_port: Option<u32>,
+    pub from_disk_cache: Option<bool>,
+    pub from_service_worker: Option<bool>,
+    pub from_prefetch_cache: Option<bool>,
+    pub encoded_data_length: u64,
+    pub protocol: Option<String>,
+    // pub timing: Option<ResourceTiming>,
+    // pub security_state: SecurityState,
+    // pub security_details: Option<SecurityDetails>,
+}
+
 pub mod events {
     use serde::{Deserialize, Serialize};
 
@@ -54,10 +80,48 @@ pub mod events {
         pub response_headers: Option<super::Headers>,
     }
 
+    #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+    pub enum ResourceType {
+        Document,
+        Stylesheet,
+        Image,
+        Media,
+        Font,
+        Script,
+        TextTrack,
+        XHR,
+        Fetch,
+        EventSource,
+        WebSocket,
+        Manifest,
+        SignedExchange,
+        Ping,
+        CSPViolationReport,
+        Other,
+    }
+
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct RequestInterceptedEvent {
         pub params: RequestInterceptedEventParams,
+    }
+
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ResponseReceivedEventParams {
+        pub request_id: String,
+        pub loader_id: String,
+        pub timestamp: f64,
+        #[serde(rename = "type")]
+        pub _type: ResourceType,
+        pub response: super::Response,
+        pub frame_id: Option<String>,
+    }
+
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ResponseReceivedEvent {
+        pub params: ResponseReceivedEventParams,
     }
 
     #[test]
@@ -197,6 +261,24 @@ pub mod methods {
     impl<'a> Method for GetResponseBodyForInterception<'a> {
         const NAME: &'static str = "Network.getResponseBodyForInterception";
         type ReturnObject = GetResponseBodyForInterceptionReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct GetResponseBody<'a> {
+        pub request_id: &'a str,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct GetResponseBodyReturnObject {
+        pub body: String,
+        pub base64_encoded: bool,
+    }
+
+    impl<'a> Method for GetResponseBody<'a> {
+        const NAME: &'static str = "Network.getResponseBody";
+        type ReturnObject = GetResponseBodyReturnObject;
     }
 
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -496,5 +496,6 @@ fn get_script_source() -> Result<(), failure::Error> {
         contents
     );
 
+
     Ok(())
 }


### PR DESCRIPTION
Adds a `Tab::enable_response_handler` method that installs a callback that will be called for each finished network request.

The callback receives the response info, and also a additional method that retrieves the payload. (I'm not so sure about that one, but I think it's the most straight-forward solution)

A test is included. 

Closes #132