### PR TITLE
bug/tab: stop wait_until_navigated from hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Changed
 
+* [Fixed a race condition in Tab.wait_until_navigated](https://github.com/atroche/rust-headless-chrome/pull/135)
+
 
 ## 0.1.5 - 2019-06-19
 

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -19,8 +19,6 @@ use crate::protocol::{network, Event, RemoteError};
 use crate::{protocol, util};
 
 use super::transport::SessionId;
-use crate::protocol::dom::Node;
-use std::time::Duration;
 
 pub mod element;
 mod keys;
@@ -224,17 +222,7 @@ impl<'a> Tab {
     }
 
     pub fn wait_until_navigated(&self) -> Result<&Self, Error> {
-        debug!("waiting to start navigating");
-        // wait for navigating to go to true
         let navigating = Arc::clone(&self.navigating);
-        util::Wait::with_timeout(Duration::from_secs(20)).until(|| {
-            if navigating.load(Ordering::SeqCst) {
-                Some(true)
-            } else {
-                None
-            }
-        })?;
-        debug!("A tab started navigating");
 
         util::Wait::with_timeout(Duration::from_secs(20)).until(|| {
             if navigating.load(Ordering::SeqCst) {
@@ -253,6 +241,9 @@ impl<'a> Tab {
         if let Some(error_text) = return_object.error_text {
             return Err(NavigationFailed { error_text }.into());
         }
+
+        let navigating = Arc::clone(&self.navigating);
+        navigating.store(true, Ordering::SeqCst);
 
         info!("Navigating a tab to {}", url);
 

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
+use std::time::Duration;
 
 use failure::{Error, Fail};
 use log::*;
@@ -11,6 +12,7 @@ use element::Element;
 use point::Point;
 
 use crate::browser::Transport;
+use crate::protocol::dom::Node;
 use crate::protocol::page::methods::Navigate;
 use crate::protocol::target::TargetId;
 use crate::protocol::target::TargetInfo;
@@ -156,7 +158,9 @@ impl<'a> Tab {
             for event in incoming_events_rx {
                 match event {
                     Event::Lifecycle(lifecycle_event) => {
-                        match lifecycle_event.params.name.as_ref() {
+                        let event_name = lifecycle_event.params.name.as_ref();
+                        trace!("Lifecycle event: {}", event_name);
+                        match event_name {
                             "networkAlmostIdle" => {
                                 navigating.store(false, Ordering::SeqCst);
                             }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -460,3 +460,23 @@ fn get_script_source() -> Result<(), failure::Error> {
 
     Ok(())
 }
+
+#[test]
+fn wait_until_navigated_does_not_hang() -> Result<(), failure::Error> {
+    logging::enable_logging();
+    let server = server::file_server("tests/coverage_fixtures");
+
+    // TODO: extract this oft-repeated call. default?
+    let browser = Browser::new(
+        LaunchOptionsBuilder::default()
+            .path(Some(default_executable().unwrap()))
+            .build()
+            .unwrap(),
+    )
+    .unwrap();
+
+    let tab: Arc<Tab> = browser.wait_for_initial_tab()?;
+
+    tab.wait_until_navigated()?;
+    Ok(())
+}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -422,6 +422,7 @@ fn get_script_source() -> Result<(), failure::Error> {
     let browser = Browser::new(
         LaunchOptionsBuilder::default()
             .path(Some(default_executable().unwrap()))
+            // TODO: does this need to be false?
             .headless(false)
             .build()
             .unwrap(),


### PR DESCRIPTION
Previously, a call to `wait_until_navigated` would time out if `Tab.navigating` was false, which can happen when a) you haven't told the tab to navigate or b) the navigation finishes before `wait_until_navigated` finishes.

@theduke I reckon this will fix the intermittent failures [you encountered](https://github.com/atroche/rust-headless-chrome/pull/133#discussion_r298806232)

See also: [some notes I took while working on this](https://paper.dropbox.com/doc/Navigation-in-headless_chrome--AgCNa0JHNG4ouDv5R_m~2Ip6AQ-viXQEuMOi3HXHeD58oZYi).