### PR TITLE
Fix missing failure-feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ script:
     cargo clippy --all --tests --examples;
     fi
   - env RUST_BACKTRACE=1 RUST_LOG=headless_chrome=trace cargo test -- --nocapture
+  - cargo test --no-default-features
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
     cargo test --doc --features nightly README;
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ regex = "1"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 serde_derive = "1"
-failure = { version = "0.1", default_features = false, features = ["std"] }
+failure = "0.1"
 log = "0.4"
 env_logger = "0.6"
 rand = "0.7"


### PR DESCRIPTION
Removing the `default_features` for `failure` removed the `derive` feature, which sneaked back in if `headless_chrome` was compiled with default features enabled. Current master and `0.4.0` will not compile for `cargo check --no-default-features` or as a dependency `rust_headless_chrome = { version = "0.4", default_features = false}`. This went unnoticed because CI does not test with `--no-default-features`.

This re-introduces the default features on `failure` and introduces extra testing for CI. The currently release `0.4` should be yanked and `0.4.1` released.