### PR TITLE
Re-enable and fix response handling test, add docstring which warns of limitations

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -637,6 +637,19 @@ impl<'a> Tab {
         Ok(())
     }
 
+    /// Lets you listen for responses, and gives you a way to get the response body too.
+    ///
+    /// Please note that the 'response' does not include the *body* of the response -- Chrome tells
+    /// us about them seperately (because you might quickly get the status code and headers from a
+    /// server well before you receive the entire response body which could, after all, be gigabytes
+    /// long).
+    ///
+    /// Currently we leave it up to the caller to decide when to call `fetch_body` (the second
+    /// argument to the response handler), although ideally it wouldn't be possible until Chrome has
+    /// sent the `Network.loadingFinished` event.
+    ///
+    /// Currently you can only have one handler registered, but ideally there would be no limit and
+    /// we'd give you a mechanism to deregister the handler too.
     pub fn enable_response_handling(&self, handler: ResponseHandler) -> Fallible<()> {
         self.call_method(network::methods::Enable {})?;
         *(self.response_handler.lock().unwrap()) = Some(handler);

--- a/tests/coverage.rs
+++ b/tests/coverage.rs
@@ -7,7 +7,7 @@ use headless_chrome::Browser;
 use server::Server;
 
 mod logging;
-mod server;
+pub mod server;
 
 fn basic_http_response(
     body: &'static str,

--- a/tests/logs.rs
+++ b/tests/logs.rs
@@ -5,7 +5,7 @@ use failure::Fallible;
 use headless_chrome::browser::tab::Tab;
 use headless_chrome::Browser;
 
-mod logging;
+pub mod logging;
 mod server;
 
 #[test]

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
@@ -441,37 +441,41 @@ fn set_request_interception() -> Fallible<()> {
     Ok(())
 }
 
-//#[test]
-//fn response_handler() -> Fallible<()> {
-//    logging::enable_logging();
-//    let server = server::Server::with_dumb_html(include_str!(
-//        "coverage_fixtures/basic_page_with_js_scripts.html"
-//    ));
-//
-//    let browser = Browser::default()?;
-//
-//    let tab = browser.wait_for_initial_tab().unwrap();
-//
-//    let responses = Arc::new(Mutex::new(Vec::new()));
-//
-//    let responses2 = responses.clone();
-//    tab.enable_response_handling(Box::new(move |response, fetch_body| {
-//        let body = fetch_body().unwrap();
-//        responses2.lock().unwrap().push((response, body));
-//    }))?;
-//
-//    tab.navigate_to(&format!("http://127.0.0.1:{}", server.port()))
-//        .unwrap();
-//
-//    tab.wait_until_navigated()?;
-//
-//    let final_responses: Vec<_> = responses.lock().unwrap().clone();
-//    assert_eq!(final_responses.len(), 3);
-//    assert_eq!(final_responses[0].0.response.mime_type, "text/html");
-//    assert!(final_responses[0].1.body.contains("Click me"));
-//
-//    Ok(())
-//}
+#[test]
+fn response_handler() -> Fallible<()> {
+    logging::enable_logging();
+    let server = server::Server::with_dumb_html(include_str!(
+        "coverage_fixtures/basic_page_with_js_scripts.html"
+    ));
+
+    let browser = Browser::default()?;
+
+    let tab = browser.wait_for_initial_tab().unwrap();
+
+    let responses = Arc::new(Mutex::new(Vec::new()));
+
+    let responses2 = responses.clone();
+    tab.enable_response_handling(Box::new(move |response, fetch_body| {
+        // NOTE: you can only fetch the body after it's been downloaded, which might be some time
+        // after the initial 'response' (with status code, headers, etc.) has come back. hence this
+        // sleep:
+        sleep(Duration::from_millis(500));
+        let body = fetch_body().unwrap();
+        responses2.lock().unwrap().push((response, body));
+    }))?;
+
+    tab.navigate_to(&format!("http://127.0.0.1:{}", server.port()))
+        .unwrap();
+
+    tab.wait_until_navigated()?;
+
+    let final_responses: Vec<_> = responses.lock().unwrap().clone();
+    assert_eq!(final_responses.len(), 3);
+    assert_eq!(final_responses[0].0.response.mime_type, "text/html");
+    assert!(final_responses[0].1.body.contains("Click me"));
+
+    Ok(())
+}
 
 #[test]
 fn incognito_contexts() -> Fallible<()> {


### PR DESCRIPTION
Fixes https://github.com/atroche/rust-headless-chrome/issues/146 and should help with https://github.com/atroche/rust-headless-chrome/issues/153