### PR TITLE
Improve Runtime Domain, Add EventListeners callbacks.

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -14,7 +14,7 @@ use crate::browser::Transport;
 use crate::protocol::dom::Node;
 use crate::protocol::page::methods::Navigate;
 use crate::protocol::target::{TargetId, TargetInfo};
-use crate::protocol::{dom, input, logs, network, page, profiler, target, Event, RemoteError};
+use crate::protocol::{dom, input, logs, network, page, profiler, runtime, target, Event, RemoteError};
 use crate::{protocol, protocol::logs::methods::ViolationSetting, util};
 
 use super::transport::SessionId;
@@ -680,6 +680,20 @@ impl<'a> Tab {
         self.call_method(network::methods::Enable {})?;
         *(self.response_handler.lock().unwrap()) = Some(handler);
         Ok(())
+    }
+
+    /// Enables runtime domain.
+    pub fn enable_runtime(&self) -> Fallible<&Self> {
+        self.call_method(runtime::methods::Enable {})?;
+
+        Ok(self)
+    }
+
+    /// Disables runtime domain
+    pub fn disable_runtime(&self) -> Fallible<&Self> {
+        self.call_method(runtime::methods::Disable {})?;
+
+        Ok(self)
     }
 
     /// Enables Debugger

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -92,7 +92,7 @@ where
     Ok(result)
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "method")]
 #[allow(clippy::large_enum_variant)]
 pub enum Event {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -120,6 +120,8 @@ pub enum Event {
     ResponseReceived(network::events::ResponseReceivedEvent),
     #[serde(rename = "Log.entryAdded")]
     LogEntryAdded(logs::events::EntryAddedEvent),
+    #[serde(rename = "Runtime.exceptionThrown")]
+    RuntimeExceptionThrown(runtime::events::ExceptionThrownEvent),
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/protocol/page.rs
+++ b/src/protocol/page.rs
@@ -1,7 +1,7 @@
 use crate::protocol::types::{JsFloat, JsUInt};
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Frame {
     pub id: String,
@@ -82,11 +82,11 @@ pub struct PrintToPdfOptions {
 pub mod events {
     use serde::Deserialize;
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct LifecycleEvent {
         pub params: LifecycleParams,
     }
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct LifecycleParams {
         pub frame_id: String,
@@ -95,31 +95,31 @@ pub mod events {
         pub timestamp: f32,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct FrameStartedLoadingEvent {
         pub params: FrameStartedLoadingParams,
     }
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct FrameStartedLoadingParams {
         pub frame_id: String,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct FrameNavigatedEvent {
         pub params: FrameNavigatedParams,
     }
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct FrameNavigatedParams {
         pub frame: super::Frame,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct FrameStoppedLoadingEvent {
         pub params: FrameStoppedLoadingParams,
     }
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct FrameStoppedLoadingParams {
         pub frame_id: String,

--- a/src/protocol/runtime.rs
+++ b/src/protocol/runtime.rs
@@ -179,9 +179,9 @@ pub mod methods {
 }
 
 pub mod events {
-    use serde::{Deserialize, Serialize};
-    use super::methods::{StackTrace, RemoteObject};
+    use super::methods::{RemoteObject, StackTrace};
     use crate::protocol::types::{JsInt, ScriptId};
+    use serde::{Deserialize, Serialize};
 
     /// Issued when exception was thrown and unhandled
     /// See https://chromedevtools.github.io/devtools-protocol/tot/Runtime#event-exceptionThrown

--- a/src/protocol/runtime.rs
+++ b/src/protocol/runtime.rs
@@ -154,4 +154,125 @@ pub mod methods {
         const NAME: &'static str = "Runtime.evaluate";
         type ReturnObject = EvaluateReturnObject;
     }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Enable {}
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct EnableReturnObject {}
+    impl Method for Enable {
+        const NAME: &'static str = "Runtime.enable";
+        type ReturnObject = EnableReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Disable {}
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DisableReturnObject {}
+    impl Method for Disable {
+        const NAME: &'static str = "Runtime.disable";
+        type ReturnObject = DisableReturnObject;
+    }
+}
+
+pub mod events {
+    use serde::{Deserialize, Serialize};
+    use super::methods::{StackTrace, RemoteObject};
+    use crate::protocol::types::{JsInt, ScriptId};
+
+    /// Issued when exception was thrown and unhandled
+    /// See https://chromedevtools.github.io/devtools-protocol/tot/Runtime#event-exceptionThrown
+    #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ExceptionThrown {
+        pub timestamp: f64,
+        pub exception_details: ExceptionDetails,
+    }
+
+    /// Detailed information about exception (or error) that was thrown during script compilation or execution
+    /// See https://chromedevtools.github.io/devtools-protocol/tot/Runtime#type-ExceptionDetails
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ExceptionDetails {
+        pub exception_id: JsInt,
+        pub text: String,
+        pub line_number: JsInt,
+        pub column_number: JsInt,
+        pub script_id: Option<ScriptId>,
+        pub url: Option<String>,
+        pub stack_trace: Option<StackTrace>,
+        pub exception: Option<RemoteObject>,
+        pub execution_context_id: Option<JsInt>,
+    }
+
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ExceptionThrownEvent {
+        pub params: ExceptionThrown,
+    }
+
+    #[test]
+    fn can_parse_exception_thrown_event() {
+        let message = r#"
+          {
+              "timestamp": 1566067104960.9648,
+              "exceptionDetails": {
+                "exceptionId": 14,
+                "text": "Uncaught",
+                "lineNumber": 13,
+                "columnNumber": 14,
+                "url": "http://localhost:63342/rust-headless-chrome/events_fixtures/events_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a",
+                "stackTrace": {
+                  "callFrames": [
+                    {
+                      "functionName": "thatThrows",
+                      "scriptId": "179",
+                      "url": "http://localhost:63342/rust-headless-chrome/events_fixtures/events_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a",
+                      "lineNumber": 13,
+                      "columnNumber": 14
+                    },
+                    {
+                      "functionName": "",
+                      "scriptId": "179",
+                      "url": "http://localhost:63342/rust-headless-chrome/events_fixtures/events_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a",
+                      "lineNumber": 10,
+                      "columnNumber": 6
+                    }
+                  ]
+                },
+                "exception": {
+                  "type": "object",
+                  "subtype": "error",
+                  "className": "Error",
+                  "description": "Error: Just an error thrown()\n    at thatThrows (http://localhost:63342/rust-headless-chrome/events_fixtures/events_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a:14:15)\n    at http://localhost:63342/rust-headless-chrome/events_fixtures/events_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a:11:7",
+                  "objectId": "{\"injectedScriptId\":45,\"id\":1}",
+                  "preview": {
+                    "type": "object",
+                    "subtype": "error",
+                    "description": "Error: Just an error thrown()\n    at thatThrows (http://localhost:63342/rust-headless-chrome/events_fixtures/events_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a:14:15)\n    at http://localhost:63342/rust-headless-chrome/events_fixtures/events_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a:11:7",
+                    "overflow": false,
+                    "properties": [
+                      {
+                        "name": "stack",
+                        "type": "string",
+                        "value": "Error: Just an error thrown()\n    at thatThrows (h…ts_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a:11:7"
+                      },
+                      {
+                        "name": "message",
+                        "type": "string",
+                        "value": "Just an error thrown()"
+                      }
+                    ]
+                  }
+                },
+                "executionContextId": 45
+              }
+            }
+        "#;
+
+        let _exception_thrown = serde_json::from_str::<ExceptionThrown>(message).unwrap();
+    }
 }

--- a/src/protocol/runtime.rs
+++ b/src/protocol/runtime.rs
@@ -258,7 +258,7 @@ pub mod events {
                       {
                         "name": "stack",
                         "type": "string",
-                        "value": "Error: Just an error thrown()\n    at thatThrows (h…ts_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a:11:7"
+                        "value": "Error: Just an error thrown()\n    at thatThrows (https_page.html?_ijt=mf0c1t5voa9ogu1jan2ubc781a:11:7"
                       },
                       {
                         "name": "message",

--- a/src/protocol/target.rs
+++ b/src/protocol/target.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 pub type TargetId = String;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TargetType {
     Page,
@@ -21,7 +21,7 @@ impl TargetType {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TargetInfo {
     pub target_id: TargetId,
@@ -37,12 +37,12 @@ pub struct TargetInfo {
 pub mod events {
     use serde::Deserialize;
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct AttachedToTargetEvent {
         pub params: AttachedToTargetParams,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct AttachedToTargetParams {
         pub session_id: String,
@@ -50,12 +50,12 @@ pub mod events {
         pub waiting_for_debugger: bool,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct ReceivedMessageFromTargetEvent {
         pub params: ReceivedMessageFromTargetParams,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct ReceivedMessageFromTargetParams {
         pub session_id: String,
@@ -63,34 +63,34 @@ pub mod events {
         pub message: String,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct TargetInfoChangedEvent {
         pub params: TargetInfoChangedParams,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct TargetInfoChangedParams {
         pub target_info: super::TargetInfo,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct TargetCreatedEvent {
         pub params: TargetCreatedParams,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct TargetCreatedParams {
         pub target_info: super::TargetInfo,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     pub struct TargetDestroyedEvent {
         pub params: TargetDestroyedParams,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Deserialize, Debug, Clone, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub struct TargetDestroyedParams {
         pub target_id: super::TargetId,

--- a/tests/events_fixtures/events_page.html
+++ b/tests/events_fixtures/events_page.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <script>
+      // This will log deprecation warning to console
+      const MyTag = document.registerElement('my-tag');
+
+      document.body.appendChild(new MyTag());
+
+      thatThrows();
+
+      function thatThrows() {
+        throw new Error("Just an error thrown()");
+      }
+    </script>
+  </body>
+</html>

--- a/tests/events_listeners.rs
+++ b/tests/events_listeners.rs
@@ -1,0 +1,42 @@
+use std::sync::{Arc, Mutex};
+
+use failure::Fallible;
+
+use headless_chrome::browser::tab::Tab;
+use headless_chrome::protocol::Event;
+use headless_chrome::Browser;
+
+mod server;
+
+#[test]
+fn listen_to_events() -> Fallible<()> {
+    let server = server::Server::with_dumb_html(include_str!("events_fixtures/events_page.html"));
+
+    let counter_log_entries = Arc::new(Mutex::new(0));
+    let counter_exception_thrown = Arc::new(Mutex::new(0));
+
+    let browser = Browser::default()?;
+    let tab: Arc<Tab> = browser.wait_for_initial_tab()?;
+
+    tab.enable_log()?.enable_runtime()?;
+
+    let counter_log_entries_clone = Arc::clone(&counter_log_entries);
+    let counter_exception_thrown_clone = Arc::clone(&counter_exception_thrown);
+
+    tab.add_event_listener(Box::new(move |event| match event {
+        Event::LogEntryAdded(_) => {
+            *counter_log_entries_clone.lock().unwrap() += 1;
+        }
+        Event::RuntimeExceptionThrown(_) => {
+            *counter_exception_thrown_clone.lock().unwrap() += 1;
+        }
+        _ => {}
+    }))?;
+
+    let url = format!("http://127.0.0.1:{}", server.port());
+    tab.navigate_to(&url)?.wait_until_navigated()?;
+
+    assert_eq!(*counter_log_entries.lock().unwrap(), 1);
+    assert_eq!(*counter_exception_thrown.lock().unwrap(), 1);
+    Ok(())
+}

--- a/tests/events_listeners.rs
+++ b/tests/events_listeners.rs
@@ -23,7 +23,7 @@ fn listen_to_events() -> Fallible<()> {
     let counter_log_entries_clone = Arc::clone(&counter_log_entries);
     let counter_exception_thrown_clone = Arc::clone(&counter_exception_thrown);
 
-    tab.add_event_listener(Box::new(move |event| match event {
+    tab.add_event_listener(Arc::new(move |event: &Event| match event {
         Event::LogEntryAdded(_) => {
             *counter_log_entries_clone.lock().unwrap() += 1;
         }
@@ -38,5 +38,42 @@ fn listen_to_events() -> Fallible<()> {
 
     assert_eq!(*counter_log_entries.lock().unwrap(), 1);
     assert_eq!(*counter_exception_thrown.lock().unwrap(), 1);
+    Ok(())
+}
+
+#[test]
+fn remove_event_listener() -> Fallible<()> {
+    let server = server::Server::with_dumb_html(include_str!("events_fixtures/events_page.html"));
+
+    let counter_log_entries = Arc::new(Mutex::new(0));
+    let counter_exception_thrown = Arc::new(Mutex::new(0));
+
+    let browser = Browser::default()?;
+    let tab: Arc<Tab> = browser.wait_for_initial_tab()?;
+
+    tab.enable_log()?.enable_runtime()?;
+
+    let counter_log_entries_clone = Arc::clone(&counter_log_entries);
+    let counter_exception_thrown_clone = Arc::clone(&counter_exception_thrown);
+
+    tab.add_event_listener(Arc::new(move |event: &Event| {
+        if let Event::LogEntryAdded(_) = event {
+            *counter_log_entries_clone.lock().unwrap() += 1;
+        }
+    }))?;
+
+    let runtime_listener = tab.add_event_listener(Arc::new(move |event: &Event| {
+        if let Event::RuntimeExceptionThrown(_) = event {
+            *counter_exception_thrown_clone.lock().unwrap() += 1;
+        }
+    }))?;
+
+    tab.remove_event_listener(&runtime_listener)?;
+
+    let url = format!("http://127.0.0.1:{}", server.port());
+    tab.navigate_to(&url)?.wait_until_navigated()?;
+
+    assert_eq!(*counter_log_entries.lock().unwrap(), 1);
+    assert_eq!(*counter_exception_thrown.lock().unwrap(), 0);
     Ok(())
 }


### PR DESCRIPTION
Adds `Runtime.enable` and `Runtime.disable` methods, so you can receive `runtime` events.

Adds event listener to listen to the events (see `tests/events_listeners.rs` for more details). 

Relates #106 