### PR TITLE
Remove fetch as default feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 ### Removed
 ### Changed
 
+*  **BREAKING CHANGE**: Remove the 'fetch' feature (which enables the fetcher module) from default features.
+
 ## 0.7.0 - 2019-08-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,6 @@ name = "headless_chrome"
 path = "src/lib.rs"
 
 [features]
-default = [ "fetch" ]
+default = []
 fetch = [ "ureq", "directories", "zip" ]
 nightly = []

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![API](https://docs.rs/headless_chrome/badge.svg)](https://docs.rs/headless_chrome)
 [![Discord channel](https://img.shields.io/discord/557374784233799681.svg?logo=discord)](https://discord.gg/yyGEzcc)
 
-[Puppeteer](https://github.com/GoogleChrome/puppeteer) for Rust. It looks a little something like this:
-
 A high-level API to control headless Chrome or Chromium over the DevTools Protocol. It is the
 Rust equivalent of [Puppeteer](https://github.com/GoogleChrome/puppeteer), a Node library
 maintained by the Chrome DevTools team.
@@ -107,12 +105,6 @@ By default, `headless_chrome` will download a compatible version of chrome to `X
 [dependencies.headless_chrome]
 default-features = false
 ```
-
-## Missing features
-
-- Frame / iframe support
-- `window.alert` handlers
-- Frankly, most of what's possible using the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/tot)
 
 ## Contributing
 


### PR DESCRIPTION
I think it's a bit dangerous having it as a default when we're not testing it on CI, and when we're not regularly using it ourselves. There are probably more issues like this lurking: https://github.com/atroche/rust-headless-chrome/issues/143