### PR TITLE
Tabs additional functions

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -329,6 +329,14 @@ impl Browser {
                             }
                             Event::TargetDestroyed(ev) => {
                                 trace!("Target destroyed: {:?}", ev.params.target_id);
+                                let mut locked_tabs = tabs.lock().unwrap();
+                                let pos = locked_tabs
+                                    .iter()
+                                    .position(|tab| *tab.get_target_id() == ev.params.target_id);
+
+                                if let Some(idx) = pos {
+                                    locked_tabs.remove(idx);
+                                }
                             }
                             _ => {
                                 let mut raw_event = format!("{:?}", event);

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -874,11 +874,10 @@ impl<'a> Tab {
 
     /// Activates (focuses) the target.
     pub fn activate(&self) -> Fallible<&Self> {
-        self
-            .call_method(protocol::target::methods::ActivateTarget {
-                target_id: self.get_target_id(),
-            })
-            .map(|_| self)
+        self.call_method(protocol::target::methods::ActivateTarget {
+            target_id: self.get_target_id(),
+        })
+        .map(|_| self)
     }
 
     /// Get position and size of the browser window associated with this `Tab`.

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -850,6 +850,28 @@ impl<'a> Tab {
         Ok(())
     }
 
+    /// Closes the target Page
+    pub fn close_target(&self) -> Fallible<bool> {
+        self.call_method(protocol::target::methods::CloseTarget {
+            target_id: self.get_target_id(),
+        })
+        .map(|r| r.success)
+    }
+
+    /// Tries to close page, running its beforeunload hooks, if any
+    pub fn close_with_unload(&self) -> Fallible<bool> {
+        self.call_method(protocol::page::methods::Close {})
+            .map(|_| true)
+    }
+
+    /// Calls one of the close_* methods depending on fire_unload option
+    pub fn close(&self, fire_unload: bool) -> Fallible<bool> {
+        if fire_unload {
+            return self.close_with_unload();
+        }
+        self.close_target()
+    }
+
     /// Get position and size of the browser window associated with this `Tab`.
     ///
     /// Note that the returned bounds are always specified for normal (windowed)

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -872,6 +872,15 @@ impl<'a> Tab {
         self.close_target()
     }
 
+    /// Activates (focuses) the target.
+    pub fn activate(&self) -> Fallible<&Self> {
+        self
+            .call_method(protocol::target::methods::ActivateTarget {
+                target_id: self.get_target_id(),
+            })
+            .map(|_| self)
+    }
+
     /// Get position and size of the browser window associated with this `Tab`.
     ///
     /// Note that the returned bounds are always specified for normal (windowed)

--- a/src/protocol/page.rs
+++ b/src/protocol/page.rs
@@ -236,6 +236,18 @@ pub mod methods {
         type ReturnObject = NavigateReturnObject;
     }
 
+    /// Tries to close page, running its beforeunload hooks, if any
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Close {}
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct CloseReturnObject {}
+    impl Method for Close {
+        const NAME: &'static str = "Page.close";
+        type ReturnObject = CloseReturnObject;
+    }
+
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct Enable {}

--- a/src/protocol/target.rs
+++ b/src/protocol/target.rs
@@ -225,4 +225,20 @@ pub mod methods {
         const NAME: &'static str = "Target.sendMessageToTarget";
         type ReturnObject = SendMessageToTargetReturnObject;
     }
+
+    /// Closes the target. If the target is a page that gets closed too.
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct CloseTarget<'a> {
+        pub target_id: &'a str,
+    }
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct CloseTargetReturnObject {
+        pub success: bool,
+    }
+    impl<'a> Method for CloseTarget<'a> {
+        const NAME: &'static str = "Target.closeTarget";
+        type ReturnObject = CloseTargetReturnObject;
+    }
 }

--- a/src/protocol/target.rs
+++ b/src/protocol/target.rs
@@ -229,6 +229,20 @@ pub mod methods {
     /// Closes the target. If the target is a page that gets closed too.
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
+    pub struct ActivateTarget<'a> {
+        pub target_id: &'a str,
+    }
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ActivateTargetReturnObject {}
+    impl<'a> Method for ActivateTarget<'a> {
+        const NAME: &'static str = "Target.activateTarget";
+        type ReturnObject = ActivateTargetReturnObject;
+    }
+
+    /// Closes the target. If the target is a page that gets closed too.
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
     pub struct CloseTarget<'a> {
         pub target_id: &'a str,
     }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -655,3 +655,33 @@ fn get_cookies() -> Fallible<()> {
 
     Ok(())
 }
+
+#[test]
+fn close_tabs() -> Fallible<()> {
+    let (server, browser, tab) = dumb_server(include_str!("simple.html"));
+    let tabs = browser.get_tabs();
+
+    let check_tabs = |num: usize| {
+        let num_tabs = tabs.lock().unwrap().len();
+        assert_eq!(num_tabs, num);
+    };
+    check_tabs(1);
+
+    let new_tab1 = browser.new_tab()?;
+    new_tab1.navigate_to( &format!("http://127.0.0.1:{}", server.port()))?;
+    check_tabs(2);
+
+    let new_tab2 = browser.new_tab()?;
+    new_tab2.navigate_to( &format!("http://127.0.0.1:{}", server.port()))?;
+    check_tabs(3);
+
+    let closed = new_tab1.close_target()?;
+    println!("{:?}", closed);
+//    assert_eq!(closed, true);
+//    check_tabs(2);
+//
+//    new_tab2.close_with_unload()?;
+//    check_tabs(1);
+
+    Ok(())
+}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -668,20 +668,28 @@ fn close_tabs() -> Fallible<()> {
     check_tabs(1);
 
     let new_tab1 = browser.new_tab()?;
-    new_tab1.navigate_to( &format!("http://127.0.0.1:{}", server.port()))?;
+    new_tab1
+        .navigate_to(&format!("http://127.0.0.1:{}", server.port()))?
+        .wait_until_navigated()?;
     check_tabs(2);
 
     let new_tab2 = browser.new_tab()?;
-    new_tab2.navigate_to( &format!("http://127.0.0.1:{}", server.port()))?;
+    new_tab2
+        .navigate_to(&format!("http://127.0.0.1:{}", server.port()))?
+        .wait_until_navigated()?;
+
     check_tabs(3);
 
-    let closed = new_tab1.close_target()?;
-    println!("{:?}", closed);
-//    assert_eq!(closed, true);
-//    check_tabs(2);
-//
-//    new_tab2.close_with_unload()?;
-//    check_tabs(1);
+    let closed = new_tab1.close(true)?;
+
+    assert_eq!(closed, true);
+
+    std::thread::sleep(Duration::from_millis(500));
+    check_tabs(2);
+
+    std::thread::sleep(Duration::from_millis(500));
+    new_tab2.close_with_unload()?;
+    check_tabs(1);
 
     Ok(())
 }


### PR DESCRIPTION
Add next functionality to tabs:

1. `Tab#close_target`  - closes the tab.
2. `Tab#close_with_unload` - tries to close the tab, but emits `beforeunload` event.
3. `Tab#close(boolean)` - helper function that chooses one of the functions above depending on the boolean parameter.
4. `Tab#activate` - activates current tab (makes it focus).