### PR TITLE
Easier access to launch options builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 ### Removed
 ### Changed
+* Move env_logger to dev dependencies 
 
 ## 0.9.0 - 2019-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased](https://github.com/atroche/rust-headless-chrome/compare/v0.9.0...HEAD)
 
 ### Added
+* `LaunchOptions::default_builder()` for easier access to LaunchOptionsBuilder (which, because it's created via `derive(Builder)` is hard for editors to deal with
 ### Removed
 ### Changed
 * Move env_logger to dev dependencies 

--- a/examples/query_wikipedia.rs
+++ b/examples/query_wikipedia.rs
@@ -1,10 +1,10 @@
 use failure::Fallible;
 
-use headless_chrome::{Browser, LaunchOptionsBuilder};
+use headless_chrome::{Browser, LaunchOptions};
 
 fn query(input: &str) -> Fallible<()> {
     let browser = Browser::new(
-        LaunchOptionsBuilder::default()
+        LaunchOptions::default_builder()
             .build()
             .expect("Could not find chrome-executable"),
     )?;

--- a/examples/take_screenshot.rs
+++ b/examples/take_screenshot.rs
@@ -2,13 +2,13 @@ use std::fs;
 
 use failure::Fallible;
 
-use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptionsBuilder};
+use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptions};
 
 fn main() -> Fallible<()> {
     // Create a headless browser, navigate to wikipedia.org, wait for the page
     // to render completely, take a screenshot of the entire page
     // in JPEG-format using 75% quality.
-    let options = LaunchOptionsBuilder::default()
+    let options = LaunchOptions::default_builder()
         .build()
         .expect("Couldn't find appropriate Chrome binary.");
     let browser = Browser::new(options)?;

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -8,8 +8,8 @@ use failure::Fallible;
 use log::*;
 use serde;
 
-pub use process::LaunchOptionsBuilder;
-use process::{LaunchOptions, Process};
+use process::Process;
+pub use process::{LaunchOptions, LaunchOptionsBuilder};
 pub use tab::Tab;
 use transport::Transport;
 use which::which;
@@ -94,7 +94,7 @@ impl Browser {
     /// Calls [`new`] with options to launch a headless browser using whatever Chrome / Chromium
     /// binary can be found on the system.
     pub fn default() -> Fallible<Self> {
-        let launch_options = LaunchOptionsBuilder::default()
+        let launch_options = LaunchOptions::default_builder()
             .path(Some(default_executable().unwrap()))
             .build()
             .unwrap();

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -107,11 +107,15 @@ pub struct LaunchOptions<'a> {
     pub process_envs: Option<HashMap<String, String>>,
 }
 
+impl<'a> LaunchOptions<'a> {
+    pub fn default_builder() -> LaunchOptionsBuilder<'a> {
+        LaunchOptionsBuilder::default()
+    }
+}
+
 #[cfg(feature = "fetch")]
 impl<'a> LaunchOptionsBuilder<'a> {
-    fn default_revision(&self) -> &'static str {
-        fetcher::CUR_REV
-    }
+    fn default_revision(&self) -> &'static str {}
 }
 
 /// These are passed to the Chrome binary by default.
@@ -357,7 +361,7 @@ mod tests {
     fn can_launch_chrome_and_get_ws_url() {
         setup();
         let chrome = super::Process::new(
-            LaunchOptionsBuilder::default()
+            LaunchOptions::default_builder()
                 .path(Some(default_executable().unwrap()))
                 .build()
                 .unwrap(),
@@ -401,7 +405,7 @@ mod tests {
         setup();
         {
             let _chrome = &mut super::Process::new(
-                LaunchOptionsBuilder::default()
+                LaunchOptions::default_builder()
                     .path(Some(default_executable().unwrap()))
                     .build()
                     .unwrap(),
@@ -423,7 +427,7 @@ mod tests {
                 // these sleeps are to make it more likely the chrome startups will overlap
                 std::thread::sleep(std::time::Duration::from_millis(10));
                 let chrome = super::Process::new(
-                    LaunchOptionsBuilder::default()
+                    LaunchOptions::default_builder()
                         .path(Some(default_executable().unwrap()))
                         .build()
                         .unwrap(),
@@ -448,7 +452,7 @@ mod tests {
 
         for _ in 0..10 {
             let chrome = super::Process::new(
-                LaunchOptionsBuilder::default()
+                LaunchOptions::default_builder()
                     .path(Some(default_executable().unwrap()))
                     .headless(true)
                     .build()

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -139,8 +139,8 @@ impl<'a> Element<'a> {
     /// # use failure::Fallible;
     /// # fn main() -> Fallible<()> {
     /// #
-    /// use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptionsBuilder};
-    /// let browser = Browser::new(LaunchOptionsBuilder::default().build().unwrap())?;
+    /// use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptions};
+    /// let browser = Browser::new(LaunchOptions::default_builder().build().unwrap())?;
     /// let png_data = browser.wait_for_initial_tab()?
     ///     .navigate_to("https://en.wikipedia.org/wiki/WebKit")?
     ///     .wait_for_element("#mw-content-text > div > table.infobox.vevent")?

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -530,8 +530,8 @@ impl<'a> Tab {
     /// # use failure::Fallible;
     /// # fn main() -> Fallible<()> {
     /// #
-    /// use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptionsBuilder};
-    /// let browser = Browser::new(LaunchOptionsBuilder::default().build().unwrap())?;
+    /// use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptions};
+    /// let browser = Browser::new(LaunchOptions::default_builder().build().unwrap())?;
     /// let tab = browser.wait_for_initial_tab()?;
     /// let viewport = tab.navigate_to("https://en.wikipedia.org/wiki/WebKit")?
     ///     .wait_for_element("#mw-content-text > div > table.infobox.vevent")?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ extern crate log;
 
 pub use browser::{
     tab::{element::Element, Tab},
-    Browser, LaunchOptionsBuilder,
+    Browser, LaunchOptions, LaunchOptionsBuilder,
 };
 
 pub mod browser;

--- a/src/protocol/dom.rs
+++ b/src/protocol/dom.rs
@@ -307,5 +307,4 @@ pub mod methods {
         const NAME: &'static str = "DOM.getBoxModel";
         type ReturnObject = GetBoxModelReturnObject;
     }
-
 }

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -2,12 +2,12 @@ use std::ffi::OsStr;
 
 use failure::Fallible;
 
-use headless_chrome::{browser::default_executable, Browser, LaunchOptionsBuilder};
+use headless_chrome::{browser::default_executable, Browser, LaunchOptions};
 
 #[test]
 fn test_extension() -> Fallible<()> {
     Browser::new(
-        LaunchOptionsBuilder::default()
+        LaunchOptions::default_builder()
             .path(Some(default_executable().unwrap()))
             .extensions(vec![OsStr::new("tests/extension_sampl")])
             .build()


### PR DESCRIPTION
Useful (for me!) at least until this gets solved: https://www.bountysource.com/issues/49744518-add-generated-structs-as-autocomplete-suggestions