### PR TITLE
Give min version for zip (increase zip performance)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ derive_builder = "0.7.1"
 which = "2.0"
 ureq = { version = "0.11", optional = true }
 directories = { version = "2.0", optional = true }
-zip = { version = "0.5", optional = true }
+zip = { version = "^0.5.3", optional = true }
 walkdir = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
The performance of `zip-rs` has historically not been that great, they switched recently to flate2 away from libflate, and it's been improved [a lot](https://github.com/mvdnes/zip-rs/pull/107). This PR just provides a min version number for `zip-rs`.

FYI, when the current master is run, it doesn't appear to download anything. It looks like there's another PR (#182) that gets everything working again, so I didn't spend much time with it.