### PR TITLE
Match ShadowRootType enum with ShadowRoot modes

### DIFF
--- a/src/protocol/dom.rs
+++ b/src/protocol/dom.rs
@@ -76,7 +76,7 @@ pub enum PseudoType {
 pub enum ShadowRootType {
     UserAgent,
     Open,
-    Close,
+    Closed,
 }
 
 fn attribute_deser<'de, D>(d: D) -> Result<Option<NodeAttributes>, D::Error>

--- a/tests/shadow-dom.html
+++ b/tests/shadow-dom.html
@@ -1,0 +1,24 @@
+<html>
+    <body>
+        <div>some text</div>
+        <div id="has-open"></div>
+        <div id="has-closed"></div>
+        <div id="has-other"></div>
+        <script>
+            (function makeShadowDOM() {
+                document
+                  .getElementById("has-open")
+                  .attachShadow({ mode: 'open' });
+                document
+                  .getElementById("has-closed")
+                  .attachShadow({ mode: 'closed' });
+                // has-other shadow dom should not get created,
+                // so parsing the html tag should still succeed
+                document
+                  .getElementById("has-other")
+                  .attachShadow({ mode: 'nonsense-mode-does-not-exist' });
+            })()
+        </script>
+    </body>
+</html>
+

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -705,3 +705,11 @@ fn close_tabs() -> Fallible<()> {
 
     Ok(())
 }
+
+#[test]
+fn parses_shadow_doms() -> Fallible<()> {
+    logging::enable_logging();
+    let (_, browser, tab) = dumb_server(include_str!("shadow-dom.html"));
+    tab.wait_for_element("html")?;
+    Ok(())
+}


### PR DESCRIPTION
Elements with `closed` attached shadow DOM elements currently fail to parse when you `wait_for_element`. This PR changes the `ShadowRootType` enum to match allowable shadow root modes: https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/mode