### PR TITLE
LaunchOptions, Fetch Domain, authenticate()

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -29,7 +29,7 @@ pub mod context;
 mod fetcher;
 mod process;
 pub mod tab;
-mod transport;
+pub mod transport;
 
 /// A handle to an instance of Chrome / Chromium, which wraps a WebSocket connection to its debugging port.
 ///

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -239,7 +239,12 @@ impl Process {
         args.extend(&DEFAULT_ARGS);
 
         if !launch_options.args.is_empty() {
-            args.extend(&launch_options.args)
+            let extra_args: Vec<&str> = launch_options
+                .args
+                .iter()
+                .map(|a| a.to_str().unwrap())
+                .collect();
+            args.extend(extra_args);
         }
 
         if !window_size_option.is_empty() {

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -89,6 +89,11 @@ pub struct LaunchOptions<'a> {
     #[builder(default)]
     extensions: Vec<&'a OsStr>,
 
+    /// Additional arguments to pass to the browser instance. The list of Chromium
+    /// flags can be found: http://peter.sh/experiments/chromium-command-line-switches/.
+    #[builder(default)]
+    args: Vec<&'a OsStr>,
+
     /// The options to use for fetching a version of chrome when `path` is None.
     ///
     /// By default, we'll use a revision guaranteed to work with our API and will
@@ -232,6 +237,10 @@ impl Process {
         ];
 
         args.extend(&DEFAULT_ARGS);
+
+        if !launch_options.args.is_empty() {
+            args.extend(&launch_options.args)
+        }
 
         if !window_size_option.is_empty() {
             args.extend(&[window_size_option.as_str()]);

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -12,7 +12,6 @@ use crate::protocol::runtime;
 
 mod box_model;
 
-use crate::protocol::dom::Node;
 use crate::protocol::runtime::methods::RemoteObjectType;
 pub use box_model::{BoxModel, ElementQuad};
 

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -777,12 +777,16 @@ impl Tab {
         Ok(())
     }
 
-    pub fn authenticate(&self, username: &str, password: &str) -> Fallible<&Self> {
+    pub fn authenticate(
+        &self,
+        username: Option<String>,
+        password: Option<String>,
+    ) -> Fallible<&Self> {
         let mut current_auth_handler = self.auth_handler.lock().unwrap();
         *current_auth_handler = AuthChallengeResponse {
             response: "ProvideCredentials".to_string(),
-            username: Some(username.to_string()),
-            password: Some(password.to_string()),
+            username,
+            password,
         };
         Ok(self)
     }

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -35,7 +35,7 @@ mod point;
 
 #[derive(Debug)]
 pub enum RequestPausedDecision {
-    Fulfil(fetch::methods::FulfilRequest),
+   Fulfill(fetch::methods::FulfillRequest),
     Fail(fetch::methods::FailRequest),
     Continue(Option<fetch::methods::ContinueRequest>),
 }
@@ -61,9 +61,7 @@ pub trait RequestInterceptor {
     ) -> RequestPausedDecision;
 }
 
-impl<
-        F: Fn(Arc<Transport>, SessionId, RequestPausedEvent) -> RequestPausedDecision + Send + Sync,
-    > RequestInterceptor for F
+impl<F> RequestInterceptor for F where F:  Fn(Arc<Transport>, SessionId, RequestPausedEvent) -> RequestPausedDecision + Send + Sync
 {
     fn intercept(
         &self,
@@ -277,7 +275,7 @@ impl Tab {
                                         .map(|_| ())
                                 }
                             }
-                            RequestPausedDecision::Fulfil(fulfill_request) => transport
+                            RequestPausedDecision::Fulfill(fulfill_request) => transport
                                 .call_method_on_target(session_id.clone(), fulfill_request)
                                 .map(|_| ()),
                             RequestPausedDecision::Fail(fail_request) => transport

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -24,7 +24,7 @@ use crate::{protocol, protocol::logs::methods::ViolationSetting, util};
 use super::transport::SessionId;
 use crate::protocol::fetch::methods::{AuthChallengeResponse, ContinueRequest};
 use crate::protocol::network::methods::SetExtraHTTPHeaders;
-use crate::protocol::network::Cookie;
+use crate::protocol::network::{Cookie, CookieParam};
 use std::collections::HashMap;
 use std::thread::sleep;
 
@@ -1034,6 +1034,12 @@ impl Tab {
         Ok(self
             .call_method(network::methods::GetCookies { urls: None })?
             .cookies)
+    }
+
+    /// Sets the cookies
+    pub fn set_cookies(&self, cookies: &[CookieParam]) -> Fallible<()> {
+        self.call_method(network::methods::SetCookies { cookies })?;
+        Ok(())
     }
 
     /// Returns the title of the document.

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -23,7 +23,9 @@ use crate::{protocol, protocol::logs::methods::ViolationSetting, util};
 
 use super::transport::SessionId;
 use crate::protocol::fetch::methods::{AuthChallengeResponse, ContinueRequest};
+use crate::protocol::network::methods::SetExtraHTTPHeaders;
 use crate::protocol::network::Cookie;
+use std::collections::HashMap;
 use std::thread::sleep;
 
 pub mod element;
@@ -235,7 +237,6 @@ impl Tab {
                         }
                     }
                     Event::RequestPaused(event) => {
-                        println!("Received Event: {:#?}", event);
                         let interceptor = interceptor_mutex.lock().unwrap();
                         let decision =
                             interceptor(Arc::clone(&transport), session_id.clone(), event.clone());
@@ -1078,6 +1079,12 @@ impl Tab {
         files: Option<Vec<String>>,
     ) -> Fallible<()> {
         self.call_method(HandleFileChooser { action, files })?;
+        Ok(())
+    }
+
+    pub fn set_extra_http_headers(&self, headers: HashMap<&str, &str>) -> Fallible<()> {
+        self.call_method(network::methods::Enable {})?;
+        self.call_method(SetExtraHTTPHeaders { headers })?;
         Ok(())
     }
 }

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -280,7 +280,6 @@ impl Transport {
                                     let raw_message = target_message_event.params.message;
 
                                     let msg_res = protocol::parse_raw_message(&raw_message);
-
                                     match msg_res {
                                         Ok(target_message) => match target_message {
                                             Message::Event(target_event) => {

--- a/src/protocol/dom.rs
+++ b/src/protocol/dom.rs
@@ -76,7 +76,7 @@ pub enum PseudoType {
 pub enum ShadowRootType {
     UserAgent,
     Open,
-    Close,
+    Closed,
 }
 
 fn attribute_deser<'de, D>(d: D) -> Result<Option<NodeAttributes>, D::Error>

--- a/src/protocol/fetch.rs
+++ b/src/protocol/fetch.rs
@@ -166,7 +166,7 @@ pub mod methods {
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct GetResponseBody<'a> {
-        request_id: &'a str,
+        pub request_id: &'a str,
     }
 
     #[derive(Deserialize, Debug)]

--- a/src/protocol/fetch.rs
+++ b/src/protocol/fetch.rs
@@ -1,0 +1,238 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct HeaderEntry {
+    pub name: String,
+    pub value: String,
+}
+
+pub mod methods {
+    use crate::protocol::network::ErrorReason;
+    use crate::protocol::types::JsUInt;
+    use crate::protocol::Method;
+    use serde::{Deserialize, Serialize};
+
+    /// Fetch.enable
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct RequestPattern<'a> {
+        /// Wildcards ('*' -> zero or more, '?' -> exactly one) are allowed.
+        /// Escape character is backslash. Omitting is equivalent to "*".
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub url_pattern: Option<&'a str>,
+        /// Resource type as it was perceived by the rendering engine.
+        ///
+        /// Allowed values:
+        /// Document, Stylesheet, Image, Media, Font, Script, TextTrack, XHR, Fetch, EventSource, WebSocket, Manifest, SignedExchange, Ping, CSPViolationReport, Other
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub resource_type: Option<&'a str>,
+
+        /// Stages of the interception to begin intercepting. Request will intercept before the
+        /// request is sent. Response will intercept after the response is received.
+        ///
+        /// Allowed values:
+        /// Request, HeadersReceived
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub request_stage: Option<&'a str>,
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Enable<'a> {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub patterns: Option<&'a [RequestPattern<'a>]>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub handle_auth_requests: Option<bool>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct EnableReturnObject {}
+
+    impl<'a> Method for Enable<'a> {
+        const NAME: &'static str = "Fetch.enable";
+        type ReturnObject = EnableReturnObject;
+    }
+
+    /// Fetch.disable
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Disable {}
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DisableReturnObject {}
+
+    impl Method for Disable {
+        const NAME: &'static str = "Fetch.disable";
+        type ReturnObject = DisableReturnObject;
+    }
+
+    /// Fetch.failRequest
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FailRequest {
+        request_id: String,
+        error_reason: ErrorReason,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FailRequestReturnObject {}
+
+    impl Method for FailRequest {
+        const NAME: &'static str = "Fetch.failRequest";
+        type ReturnObject = FailRequestReturnObject;
+    }
+
+    /// Fetch.fulfillRequest
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FulfilRequest {
+        pub request_id: String,
+        pub response_code: JsUInt,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub response_headers: Option<Vec<super::HeaderEntry>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub binary_response_headers: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub body: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub response_phrase: Option<String>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct FulfilRequestReturnObject {}
+
+    impl Method for FulfilRequest {
+        const NAME: &'static str = "Fetch.fulfillRequest";
+        type ReturnObject = FulfilRequestReturnObject;
+    }
+
+    /// Fetch.continueRequest
+    #[derive(Debug, Serialize, Default)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ContinueRequest {
+        pub request_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub method: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub post_data: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub headers: Option<Vec<super::HeaderEntry>>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ContinueRequestReturnObject {}
+
+    impl Method for ContinueRequest {
+        const NAME: &'static str = "Fetch.continueRequest";
+        type ReturnObject = ContinueRequestReturnObject;
+    }
+
+    /// Fetch.continueWithAuth
+    #[derive(Serialize, Debug, Clone, Default)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthChallengeResponse {
+        /// Possible values: Default, CancelAuth, ProvideCredentials
+        pub response: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub username: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub password: Option<String>,
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ContinueWithAuth<'a> {
+        pub request_id: &'a str,
+        pub auth_challenge_response: AuthChallengeResponse,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ContinueWithAuthReturnObject {}
+
+    impl<'a> Method for ContinueWithAuth<'a> {
+        const NAME: &'static str = "Fetch.continueWithAuth";
+        type ReturnObject = ContinueWithAuthReturnObject;
+    }
+
+    /// Fetch.getResponseBody
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct GetResponseBody<'a> {
+        request_id: &'a str,
+    }
+
+    #[derive(Deserialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct GetResponseBodyReturnObject {
+        pub body: String,
+        pub base64_encoded: bool,
+    }
+
+    impl<'a> Method for GetResponseBody<'a> {
+        const NAME: &'static str = "Fetch.getResponseBody";
+        type ReturnObject = GetResponseBodyReturnObject;
+    }
+}
+
+pub mod events {
+    use crate::protocol::network::events::ResourceType;
+    use crate::protocol::network::{ErrorReason, Request};
+    use crate::protocol::types::JsUInt;
+    use serde::{Deserialize, Serialize};
+
+    /// Fetch.requestPaused
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct RequestPausedEvent {
+        pub params: RequestPausedEventParams,
+    }
+
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct RequestPausedEventParams {
+        pub request_id: String,
+        pub request: Request,
+        pub frame_id: String,
+        pub resource_type: ResourceType,
+        pub response_error_reason: Option<ErrorReason>,
+        pub response_status_code: Option<JsUInt>,
+        pub response_headers: Option<Vec<super::HeaderEntry>>,
+        pub network_id: Option<String>,
+    }
+
+    /// Fetch.authRequired
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthChallenge {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        /// Source of the authentication challenge. Allowed values: Server, Proxy
+        pub source: Option<String>,
+        pub origin: String,
+        pub scheme: String,
+        pub realm: String,
+    }
+
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthRequiredEvent {
+        pub params: AuthRequiredEventParams,
+    }
+
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AuthRequiredEventParams {
+        pub request_id: String,
+        pub request: Request,
+        pub frame_id: String,
+        pub resource_type: ResourceType,
+        pub auth_challenge: AuthChallenge,
+    }
+}

--- a/src/protocol/fetch.rs
+++ b/src/protocol/fetch.rs
@@ -88,7 +88,7 @@ pub mod methods {
     /// Fetch.fulfillRequest
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
-    pub struct FulfilRequest {
+    pub struct FulfillRequest {
         pub request_id: String,
         pub response_code: JsUInt,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -103,11 +103,11 @@ pub mod methods {
 
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
-    pub struct FulfilRequestReturnObject {}
+    pub struct FulfillRequestReturnObject {}
 
-    impl Method for FulfilRequest {
+    impl Method for FulfillRequest {
         const NAME: &'static str = "Fetch.fulfillRequest";
-        type ReturnObject = FulfilRequestReturnObject;
+        type ReturnObject = FulfillRequestReturnObject;
     }
 
     /// Fetch.continueRequest

--- a/src/protocol/fetch.rs
+++ b/src/protocol/fetch.rs
@@ -72,8 +72,8 @@ pub mod methods {
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct FailRequest {
-        request_id: String,
-        error_reason: ErrorReason,
+        pub request_id: String,
+        pub error_reason: ErrorReason,
     }
 
     #[derive(Debug, Deserialize)]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 pub mod browser;
 pub mod debugger;
 pub mod dom;
+pub mod fetch;
 pub mod input;
 pub mod logs;
 pub mod network;
@@ -118,6 +119,10 @@ pub enum Event {
     RequestIntercepted(network::events::RequestInterceptedEvent),
     #[serde(rename = "Network.responseReceived")]
     ResponseReceived(network::events::ResponseReceivedEvent),
+    #[serde(rename = "Fetch.requestPaused")]
+    RequestPaused(fetch::events::RequestPausedEvent),
+    #[serde(rename = "Fetch.authRequired")]
+    AuthRequired(fetch::events::AuthRequiredEvent),
     #[serde(rename = "Log.entryAdded")]
     LogEntryAdded(logs::events::EntryAddedEvent),
     #[serde(rename = "Runtime.exceptionThrown")]

--- a/src/protocol/network.rs
+++ b/src/protocol/network.rs
@@ -84,15 +84,15 @@ pub enum CookiePriority {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct CookieParam<'a> {
-    pub name: &'a str,
-    pub value: &'a str,
+pub struct CookieParam {
+    pub name: String,
+    pub value: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<&'a str>,
+    pub url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub domain: Option<&'a str>,
+    pub domain: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub path: Option<&'a str>,
+    pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secure: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -364,7 +364,7 @@ pub mod methods {
     #[derive(Serialize, Debug, Clone)]
     #[serde(rename_all = "camelCase")]
     pub struct SetCookies<'a> {
-        pub cookies: &'a [super::CookieParam<'a>],
+        pub cookies: &'a [super::CookieParam],
     }
 
     #[derive(Deserialize, Debug, Clone)]

--- a/src/protocol/network.rs
+++ b/src/protocol/network.rs
@@ -204,8 +204,6 @@ pub mod events {
 }
 
 pub mod methods {
-    use std::collections::HashMap;
-
     use serde::{Deserialize, Serialize};
 
     use crate::protocol::network::Cookie;
@@ -247,22 +245,6 @@ pub mod methods {
         pub interception_stage: Option<&'a str>,
     }
 
-    /// DEPRECIATED, use Fetch.enable instead
-    #[derive(Serialize, Debug)]
-    #[serde(rename_all = "camelCase")]
-    pub struct SetRequestInterception<'a> {
-        pub patterns: &'a [RequestPattern<'a>],
-    }
-
-    #[derive(Deserialize, Debug, Clone)]
-    #[serde(rename_all = "camelCase")]
-    pub struct SetRequestInterceptionReturnObject {}
-
-    impl<'a> Method for SetRequestInterception<'a> {
-        const NAME: &'static str = "Network.setRequestInterception";
-        type ReturnObject = SetRequestInterceptionReturnObject;
-    }
-
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct AuthChallengeResponse<'a> {
@@ -271,36 +253,6 @@ pub mod methods {
         pub username: Option<&'a str>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub password: Option<&'a str>,
-    }
-
-    /// DEPRECIATED use Fetch.continueRequest
-    #[derive(Serialize, Debug, Default)]
-    #[serde(rename_all = "camelCase")]
-    pub struct ContinueInterceptedRequest<'a> {
-        pub interception_id: &'a str,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub error_reason: Option<&'a str>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub raw_response: Option<&'a str>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub url: Option<&'a str>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub method: Option<&'a str>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub post_data: Option<&'a str>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub headers: Option<HashMap<&'a str, &'a str>>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub auth_challenge_response: Option<AuthChallengeResponse<'a>>,
-    }
-
-    #[derive(Deserialize, Debug, Clone)]
-    #[serde(rename_all = "camelCase")]
-    pub struct ContinueInterceptedRequestReturnObject {}
-
-    impl<'a> Method for ContinueInterceptedRequest<'a> {
-        const NAME: &'static str = "Network.continueInterceptedRequest";
-        type ReturnObject = ContinueInterceptedRequestReturnObject;
     }
 
     #[derive(Serialize, Debug)]

--- a/src/protocol/network.rs
+++ b/src/protocol/network.rs
@@ -75,6 +75,39 @@ pub struct Cookie {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum CookiePriority {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CookieParam<'a> {
+    pub name: &'a str,
+    pub value: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secure: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_only: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub same_site: Option<CookieSameSite>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires: Option<JsFloat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<JsUInt>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<CookiePriority>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum ErrorReason {
     Failed,
     Aborted,
@@ -326,6 +359,21 @@ pub mod methods {
     impl<'a> Method for GetCookies {
         const NAME: &'static str = "Network.getCookies";
         type ReturnObject = GetCookiesReturnObject;
+    }
+
+    #[derive(Serialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetCookies<'a> {
+        pub cookies: &'a [super::CookieParam<'a>],
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetCookiesReturnObject {}
+
+    impl<'a> Method for SetCookies<'a> {
+        const NAME: &'static str = "Network.setCookies";
+        type ReturnObject = SetCookiesReturnObject;
     }
 
     #[derive(Serialize, Debug)]

--- a/src/protocol/network.rs
+++ b/src/protocol/network.rs
@@ -74,6 +74,24 @@ pub struct Cookie {
     pub same_site: Option<CookieSameSite>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum ErrorReason {
+    Failed,
+    Aborted,
+    TimedOut,
+    AccessDenied,
+    ConnectionClosed,
+    ConnectionReset,
+    ConnectionRefused,
+    ConnectionAborted,
+    ConnectionFailed,
+    NameNotResolved,
+    InternetDisconnected,
+    AddressUnreachable,
+    BlockedByClient,
+    BlockedByResponse,
+}
+
 pub mod events {
     use crate::protocol::types::{JsFloat, JsInt};
     use serde::{Deserialize, Serialize};
@@ -229,6 +247,7 @@ pub mod methods {
         pub interception_stage: Option<&'a str>,
     }
 
+    /// DEPRECIATED, use Fetch.enable instead
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct SetRequestInterception<'a> {
@@ -254,6 +273,7 @@ pub mod methods {
         pub password: Option<&'a str>,
     }
 
+    /// DEPRECIATED use Fetch.continueRequest
     #[derive(Serialize, Debug, Default)]
     #[serde(rename_all = "camelCase")]
     pub struct ContinueInterceptedRequest<'a> {

--- a/src/protocol/network.rs
+++ b/src/protocol/network.rs
@@ -208,6 +208,7 @@ pub mod methods {
 
     use crate::protocol::network::Cookie;
     use crate::protocol::Method;
+    use std::collections::HashMap;
 
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
@@ -325,5 +326,20 @@ pub mod methods {
     impl<'a> Method for GetCookies {
         const NAME: &'static str = "Network.getCookies";
         type ReturnObject = GetCookiesReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetExtraHTTPHeaders<'a> {
+        pub headers: HashMap<&'a str, &'a str>,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetExtraHTTPHeadersReturnObject {}
+
+    impl<'a> Method for SetExtraHTTPHeaders<'a> {
+        const NAME: &'static str = "Network.setExtraHTTPHeaders";
+        type ReturnObject = SetExtraHTTPHeadersReturnObject;
     }
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -546,6 +546,7 @@ fn authentication() -> Fallible<()> {
     tab.enable_fetch(None, Some(true))?;
     tab.navigate_to("http://httpbin.org/basic-auth/login/password")?;
     tab.wait_until_navigated()?;
+
     Ok(())
 }
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -752,10 +752,10 @@ fn set_cookies() -> Fallible<()> {
     let (server, browser, tab) = dumb_server(include_str!("simple.html"));
 
     let cookie = CookieParam {
-        name: "test",
-        value: "cookie",
+        name: "test".to_string(),
+        value: "cookie".to_string(),
         url: None,
-        domain: Some("127.0.0.1"),
+        domain: Some("127.0.0.1".to_string()),
         path: None,
         secure: None,
         http_only: None,

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -514,7 +514,7 @@ fn set_request_interception() -> Fallible<()> {
                     value: "application/javascript".to_string(),
                 }];
 
-                let fulful_request = FulfilRequest {
+                let fulfill_request = FulfillRequest {
                     request_id: intercepted.params.request_id,
                     response_code: 200,
                     response_headers: Some(headers),
@@ -523,7 +523,7 @@ fn set_request_interception() -> Fallible<()> {
                     response_phrase: None,
                 };
 
-                RequestPausedDecision::Fulfil(fulful_request)
+                RequestPausedDecision::Fulfill(fulfill_request)
             } else {
                 RequestPausedDecision::Continue(None)
             }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -542,7 +542,7 @@ fn authentication() -> Fallible<()> {
     logging::enable_logging();
     let browser = Browser::default()?;
     let tab = browser.wait_for_initial_tab()?;
-    tab.authenticate("login", "password")?;
+    tab.authenticate(Some("login".to_string()), Some("password".to_string()))?;
     tab.enable_fetch(None, Some(true))?;
     tab.navigate_to("http://httpbin.org/basic-auth/login/password")?;
     tab.wait_until_navigated()?;


### PR DESCRIPTION
Added the ability to include command line args.
Example: LaunchOptionsBuilder::default().args(vec!["--proxy-server=127.0.0.1:8888"])

Added Fetch domain, with methods: enable_fetch(), disable_fetch(), enable_request_interception(), authenticate()

Added network::SetExtraHttpHeaders protocol and set_extra_http_headers()
Added network::SetCookies protocol and set_cookies() method