### PR TITLE
Add --disable-software-rasterizer to DEFAULT_ARGS

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -116,7 +116,8 @@ impl<'a> LaunchOptions<'a> {
 
 /// These are passed to the Chrome binary by default.
 /// Via https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js#L38
-static DEFAULT_ARGS: [&str; 23] = [
+static DEFAULT_ARGS: [&str; 24] = [
+    "--disable-software-rasterizer",
     "--disable-background-networking",
     "--enable-features=NetworkService,NetworkServiceInProcess",
     "--disable-background-timer-throttling",


### PR DESCRIPTION
In alpine docker container, without this flag, chromium will raise such an error: 
```
[0218/102856.761494:ERROR:gl_implementation.cc(282)] Failed to load /usr/lib/chromium/swiftshader/libGLESv2.so: Error loading shared library /usr/lib/chromium/swiftshader/libGLESv2.so: No such file or dir
ectory
```