### PR TITLE
Add ability to specify a user data directory (profile)

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -63,12 +63,15 @@ pub struct LaunchOptions<'a> {
     /// Determintes whether to run headless version of the browser. Defaults to true.
     #[builder(default = "true")]
     headless: bool,
+
     /// Determines whether to run the browser with a sandbox.
     #[builder(default = "true")]
     sandbox: bool,
+
     /// Launch the browser with a specific window width and height.
     #[builder(default = "None")]
     window_size: Option<(u32, u32)>,
+
     /// Launch the browser with a specific debugging port.
     #[builder(default = "None")]
     port: Option<u16>,
@@ -78,6 +81,12 @@ pub struct LaunchOptions<'a> {
     /// If unspecified, the create will try to automatically detect a suitable binary.
     #[builder(default = "None")]
     path: Option<std::path::PathBuf>,
+
+    /// User Data (Profile) to use.
+    ///
+    /// If unspecified, a new temp directory is created and used on every launch.
+    #[builder(default = "None")]
+    user_data_dir: Option<std::path::PathBuf>,
 
     /// A list of Chrome extensions to load.
     ///
@@ -211,12 +220,19 @@ impl Process {
             String::from("")
         };
 
-        // NOTE: picking random data dir so that each a new browser instance is launched
-        // (see man google-chrome)
-        let user_data_dir = ::tempfile::Builder::new()
-            .prefix("rust-headless-chrome-profile")
-            .tempdir()?;
-        let data_dir_option = format!("--user-data-dir={}", user_data_dir.path().to_str().unwrap());
+        // User data directory
+        let user_data_dir = if let Some(dir) = &launch_options.user_data_dir {
+            dir.to_owned()
+        } else {
+            // picking random data dir so that each a new browser instance is launched
+            // (see man google-chrome)
+            ::tempfile::Builder::new()
+                .prefix("rust-headless-chrome-profile")
+                .tempdir()?
+                .path()
+                .to_path_buf()
+        };
+        let data_dir_option = format!("--user-data-dir={}", &user_data_dir.to_str().unwrap());
 
         trace!("Chrome will have profile: {}", data_dir_option);
 


### PR DESCRIPTION
This is helpful for performing tests/executions that rely on data stored in the user directory.

**Usage:**
```
    let browser = Browser::new(
        LaunchOptions::default_builder()
            .user_data_dir(Some(PathBuf::from("./rust-headless-chrome-profile")))
            .build()
            .expect("Could not find chrome-executable"),
    )?;
```