### PR TITLE
Type non-latin text + insert text command

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -695,6 +695,12 @@ impl<'a> Tab {
         Ok(self)
     }
 
+    /// Force stop page loading
+    pub fn stop_loading(&self) -> Fallible<&Self> {
+        self.call_method(page::methods::Stop {})?;
+        Ok(self)
+    }
+
     /// Enables the profiler
     pub fn enable_profiler(&self) -> Fallible<&Self> {
         self.call_method(profiler::methods::Enable {})?;

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -159,7 +159,10 @@ impl Transport {
         }
 
         let mut params_string = format!("{:?}", call.get_params());
-        params_string.truncate(400);
+        params_string = match params_string.char_indices().nth(400) {
+            None => params_string,
+            Some((idx, _)) => params_string[..idx].to_string(),
+        };
         trace!(
             "waiting for response from call registry: {} {:?}",
             &call_id,

--- a/src/protocol/input.rs
+++ b/src/protocol/input.rs
@@ -37,6 +37,20 @@ pub mod methods {
 
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
+    pub struct DispatchInsertText<'a> {
+        pub text: &'a str,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DispatchInsertTextReturnObject {}
+    impl<'a> Method for DispatchInsertText<'a> {
+        const NAME: &'static str = "Input.insertText";
+        type ReturnObject = DispatchInsertTextReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
     pub struct DispatchKeyEvent<'a> {
         #[serde(rename = "type")]
         pub event_type: &'a str,

--- a/src/protocol/page.rs
+++ b/src/protocol/page.rs
@@ -250,6 +250,19 @@ pub mod methods {
 
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
+    pub struct Stop {}
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct StopReturnObject {}
+
+    impl Method for Stop {
+        const NAME: &'static str = "Page.stopLoading";
+        type ReturnObject = StopReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
     pub struct Enable {}
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Allow to type non-latin text. Added method for inserting text into focused element on page.