### PR TITLE
Add Tab.wait_for_url

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -313,6 +313,19 @@ impl<'a> Tab {
         Ok(self)
     }
 
+    pub fn wait_for_url(&self, url: &str) -> Fallible<&Self> {
+        util::Wait::with_timeout(Duration::from_secs(20)).until(|| {
+            if &self.get_url() == url {
+                Some(true)
+            } else {
+                None
+            }
+        })?;
+        debug!("A tab finised navigating url");
+
+        Ok(self)
+    }
+
     pub fn navigate_to(&self, url: &str) -> Fallible<&Self> {
         let return_object = self.call_method(Navigate { url })?;
         if let Some(error_text) = return_object.error_text {


### PR DESCRIPTION
Wait until transition to the specified URL.

```rust
let tab = browser.wait_for_initial_tab()?;
tab.navigate_to("https://www.wikipedia.org")?;
tab.wait_for_element("button.pure-button.pure-button-primary-progressive")?.click()?;

tab.wait_for_url("https://ja.wikipedia.org/wiki/Special:Search?search=&go=Go")?;

println!("{}", tab.get_url()); // https://ja.wikipedia.org/wiki/Special:Search?search=&go=Go
```