### PR TITLE
Support setCookies #5

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -1033,6 +1033,54 @@ impl<'a> Tab {
             .cookies)
     }
 
+    /// Set cookies with tab's current URL
+    pub fn set_cookies(&self, cs: Vec<network::methods::SetCookie>) -> Fallible<()> {
+        // puppeteer 7b24e5435b:src/common/Page.ts :1009-1028
+        use network::methods::{SetCookie, SetCookies};
+        let url = self.get_url();
+        let starts_with_http = url.starts_with("http");
+        let cookies: Vec<SetCookie> = cs
+            .into_iter()
+            .map(|c| {
+                if c.url.is_none() && starts_with_http {
+                    SetCookie {
+                        url: Some(url.clone()),
+                        ..c
+                    }
+                } else {
+                    c
+                }
+            })
+            .collect();
+        self.delete_cookies(cookies.clone().into_iter().map(|c| c.into()).collect())?;
+        self.call_method(SetCookies { cookies })?;
+        Ok(())
+    }
+
+    /// Delete cookies with tab's current URL
+    pub fn delete_cookies(&self, cs: Vec<network::methods::DeleteCookies>) -> Fallible<()> {
+        // puppeteer 7b24e5435b:src/common/Page.ts :998-1007
+        let url = self.get_url();
+        let starts_with_http = url.starts_with("http");
+        cs.into_iter()
+            .map(|c| {
+                // REVIEW: if c.url is blank string
+                if c.url.is_none() && starts_with_http {
+                    network::methods::DeleteCookies {
+                        url: Some(url.clone()),
+                        ..c
+                    }
+                } else {
+                    c
+                }
+            })
+            .try_for_each(|c| -> Result<(), failure::Error> {
+                let _ = self.call_method(c)?;
+                Ok(())
+            })?;
+        Ok(())
+    }
+
     /// Returns the title of the document.
     ///
     /// ```rust

--- a/src/protocol/network.rs
+++ b/src/protocol/network.rs
@@ -59,6 +59,14 @@ pub enum CookieSameSite {
     None,
 }
 
+/// https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-CookiePriority
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum CookiePriority {
+    Low,
+    Medium,
+    High,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Cookie {
@@ -190,7 +198,8 @@ pub mod methods {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::protocol::network::Cookie;
+    use crate::protocol::network::{Cookie, CookiePriority, CookieSameSite};
+    use crate::protocol::types::JsFloat;
     use crate::protocol::Method;
 
     #[derive(Serialize, Debug)]
@@ -353,5 +362,82 @@ pub mod methods {
     impl<'a> Method for GetCookies {
         const NAME: &'static str = "Network.getCookies";
         type ReturnObject = GetCookiesReturnObject;
+    }
+
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-CookieParam
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setCookie
+    /// TODO: impl From<Cookie>
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetCookie {
+        pub name: String,
+        pub value: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub domain: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub path: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub secure: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub http_only: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub same_site: Option<CookieSameSite>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub expires: Option<JsFloat>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub priority: Option<CookiePriority>,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetCookieReturnObject {
+        pub success: Option<bool>,
+    }
+
+    impl<'a> Method for SetCookie {
+        const NAME: &'static str = "Network.setCookie";
+        type ReturnObject = SetCookieReturnObject;
+    }
+
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-CookieParam
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setCookies
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetCookies {
+        pub cookies: Vec<SetCookie>,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetCookiesReturnObject {}
+
+    impl<'a> Method for SetCookies {
+        const NAME: &'static str = "Network.setCookies";
+        type ReturnObject = SetCookiesReturnObject;
+    }
+
+    /// https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-deleteCookies
+    /// TODO: impl From<Cookie>
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DeleteCookies {
+        pub name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub domain: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub path: Option<String>,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "camelCase")]
+    pub struct DeleteCookiesReturnObject {}
+
+    impl<'a> Method for DeleteCookies {
+        const NAME: &'static str = "Network.deleteCookies";
+        type ReturnObject = DeleteCookiesReturnObject;
     }
 }

--- a/src/protocol/network.rs
+++ b/src/protocol/network.rs
@@ -432,6 +432,17 @@ pub mod methods {
         pub path: Option<String>,
     }
 
+    impl From<SetCookie> for DeleteCookies {
+        fn from(v: SetCookie) -> Self {
+            Self {
+                name: v.name,
+                url: v.url,
+                domain: v.domain,
+                path: v.path,
+            }
+        }
+    }
+
     #[derive(Deserialize, Debug, Clone)]
     #[serde(rename_all = "camelCase")]
     pub struct DeleteCookiesReturnObject {}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -10,7 +10,7 @@ use log::*;
 use rand::prelude::*;
 
 use headless_chrome::browser::tab::RequestInterceptionDecision;
-use headless_chrome::protocol::network::methods::RequestPattern;
+use headless_chrome::protocol::network::methods::{RequestPattern, SetCookie};
 use headless_chrome::protocol::network::Cookie;
 use headless_chrome::protocol::runtime::methods::{RemoteObjectSubtype, RemoteObjectType};
 use headless_chrome::protocol::RemoteError;
@@ -634,7 +634,7 @@ fn get_script_source() -> Fallible<()> {
 }
 
 #[test]
-fn get_cookies() -> Fallible<()> {
+fn read_write_cookies() -> Fallible<()> {
     logging::enable_logging();
     let responder = move |r: tiny_http::Request| {
         let response = tiny_http::Response::new(
@@ -653,18 +653,49 @@ fn get_cookies() -> Fallible<()> {
     let server = server::Server::new(responder);
     let (browser, tab) = dumb_client(&server);
 
-    tab.navigate_to(&server.url())?;
+    // can read cookies
+    {
+        tab.navigate_to(&server.url())?;
 
-    tab.wait_until_navigated()?;
+        tab.wait_until_navigated()?;
 
-    let cookies = tab.get_cookies()?;
+        let cookies = tab.get_cookies()?;
 
-    assert_eq!(cookies.len(), 1);
+        assert_eq!(cookies.len(), 1);
 
-    let Cookie { name, value, .. } = cookies.first().unwrap();
+        let Cookie { name, value, .. } = cookies.first().unwrap();
 
-    assert_eq!(name, "testing");
-    assert_eq!(value, "1");
+        assert_eq!(name, "testing");
+        assert_eq!(value, "1");
+
+        let t: Fallible<()> = Ok(()); // type hint for error
+        t
+    }?;
+
+    // can change (delete and set) value for current url
+    {
+        tab.set_cookies(vec![SetCookie {
+            name: "testing".to_string(),
+            value: "2".to_string(),
+            url: None,
+            domain: None,
+            path: None,
+            secure: None,
+            http_only: None,
+            same_site: None,
+            expires: None,
+            priority: None,
+        }])?;
+
+        let cookies = tab.get_cookies()?;
+        assert_eq!(cookies.len(), 1);
+        let cf = cookies.first().unwrap();
+        assert_eq!(cf.name, "testing");
+        assert_eq!(cf.value, "2");
+
+        let t: Fallible<()> = Ok(()); // type hint for error
+        t
+    }?;
 
     Ok(())
 }


### PR DESCRIPTION
Support setCookies #5

I implemented some methods the same as GetCookies.
https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-CookieParam
https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setCookie
https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-setCookies
https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-deleteCookies
Tab::{set_cookies, delete_cookies} use them with the url opened in tab, just like puppeter.

Please review.