### PR TITLE
Allow You to Specify Extra Chrome Args

### DIFF
--- a/examples/electron_like.rs
+++ b/examples/electron_like.rs
@@ -1,0 +1,23 @@
+use failure::Fallible;
+
+use headless_chrome::{Browser, LaunchOptionsBuilder};
+
+// This could possibly be used to integrate Rust as a way to create web-based desktop applications
+fn main() -> Fallible<()> {
+    // Launch chrome and point it to GitHub in "app" mode, which causes it to
+    // run without the browser tabs and headers, similar to electron.
+    let options = LaunchOptionsBuilder::default()
+        .headless(false)
+        .default_args(false)
+        .app_url(Some(
+            "https://github.com/atroche/rust-headless-chrome/issues".into(),
+        ))
+        .build()
+        .expect("Couldn't find appropriate Chrome binary.");
+    let _browser_handle = Browser::new(options)?;
+
+    // Wait 15 seconds so you can browse manually and test it
+    std::thread::sleep(std::time::Duration::from_secs(15));
+
+    Ok(())
+}


### PR DESCRIPTION
I'm experimenting with using this as an alternative backend to [Tauri](https://tauri.studio) and this PR adds the ability to customize chrome launch a little bit.

- Allow you to specify extra arbitrary chrome args
- Allow you to opt-out of the default chrome args
- Allow you to set an "app mode" URL with the LaunchOptionsBuilder
- Add an example that makes Chrome work kind of like Electron