### PR TITLE
LaunchOptionsBuilder in examples

### DIFF
--- a/examples/query_wikipedia.rs
+++ b/examples/query_wikipedia.rs
@@ -1,10 +1,10 @@
 use failure::Fallible;
 
-use headless_chrome::{Browser, LaunchOptions};
+use headless_chrome::{Browser, LaunchOptionsBuilder};
 
 fn query(input: &str) -> Fallible<()> {
     let browser = Browser::new(
-        LaunchOptions::default_builder()
+        LaunchOptionsBuilder::default()
             .build()
             .expect("Could not find chrome-executable"),
     )?;

--- a/examples/take_screenshot.rs
+++ b/examples/take_screenshot.rs
@@ -2,13 +2,13 @@ use std::fs;
 
 use failure::Fallible;
 
-use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptions};
+use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptionsBuilder};
 
 fn main() -> Fallible<()> {
     // Create a headless browser, navigate to wikipedia.org, wait for the page
     // to render completely, take a screenshot of the entire page
     // in JPEG-format using 75% quality.
-    let options = LaunchOptions::default_builder()
+    let options = LaunchOptionsBuilder::default()
         .build()
         .expect("Couldn't find appropriate Chrome binary.");
     let browser = Browser::new(options)?;


### PR DESCRIPTION
Update the examples to use LaunchOptionsBuilder instead of LaunchOptions in the Browser constructor.
As discussed in issue #203 