### PR TITLE
added css marker pseudo element

### DIFF
--- a/src/protocol/dom.rs
+++ b/src/protocol/dom.rs
@@ -69,6 +69,7 @@ pub enum PseudoType {
     ScrollbarCorner,
     Resizer,
     InputListButton,
+    Marker,
 }
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
Added the css ::marker pseudo element that resulted tab.find_element() to panic when it present in the html.