### PR TITLE
Make a connect variant which accepts idle_browser_timeout

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -106,11 +106,18 @@ impl Browser {
     }
 
     /// Allows you to drive an externally-launched Chrome process instead of launch one via [`new`].
+	/// If the browser is idle for 30 seconds, the connection will be dropped.
     pub fn connect(debug_ws_url: String) -> Fallible<Self> {
-        let transport = Arc::new(Transport::new(debug_ws_url, None, Duration::from_secs(30))?);
+        Self::connect_with_timeout(debug_ws_url, Duration::from_secs(30))
+    }
+
+    /// Allows you to drive an externally-launched Chrome process instead of launch one via [`new`].
+	/// If the browser is idle for `idle_browser_timeout`, the connection will be dropped.
+    pub fn connect_with_timeout(debug_ws_url: String, idle_browser_timeout: Duration) -> Fallible<Self> {
+        let transport = Arc::new(Transport::new(debug_ws_url, None, idle_browser_timeout)?);
         trace!("created transport");
 
-        Self::create_browser(None, transport, Duration::from_secs(30))
+        Self::create_browser(None, transport, idle_browser_timeout)
     }
 
     fn create_browser(


### PR DESCRIPTION
This is a follow-up for issue #142, extending the solution provided in PR #145.