### PR TITLE
Make LaunchOptions customizable and enable extracting midpoints after failure

### DIFF
--- a/examples/settings_and_event.rs
+++ b/examples/settings_and_event.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use failure::Fallible;
+
+use headless_chrome::{Browser, LaunchOptions, Tab, browser::tab::SyncSendEvent, protocol::Event};
+
+fn start() -> Fallible<()> {
+    let browser = Browser::new(LaunchOptions {
+        headless: false,
+        ..Default::default()
+    })?;
+
+    let tab = browser.wait_for_initial_tab().unwrap();
+
+    tab.navigate_to("https://www.google.com")
+        .expect("failed to navigate");
+
+    tab.wait_until_navigated().unwrap();
+
+    let sync_event = SyncSendEvent(
+        tab.clone(),
+        Box::new(move |event: &Event, tab: &Tab| {
+            match event {
+                Event::Lifecycle(lifecycle) => {
+                    if lifecycle.params.name == "DOMContentLoaded" {
+                        
+                        println!("{}",tab.get_url());
+                    }
+                }
+                _ => {}
+            }
+        }),
+    );
+
+    tab.add_event_listener(Arc::new(sync_event)).unwrap();
+
+    Ok(())
+}
+
+fn main() -> Fallible<()> {
+    start()
+}

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -62,22 +62,22 @@ impl Drop for TemporaryProcess {
 pub struct LaunchOptions<'a> {
     /// Determintes whether to run headless version of the browser. Defaults to true.
     #[builder(default = "true")]
-    headless: bool,
+    pub headless: bool,
     /// Determines whether to run the browser with a sandbox.
     #[builder(default = "true")]
-    sandbox: bool,
+    pub sandbox: bool,
     /// Launch the browser with a specific window width and height.
     #[builder(default = "None")]
-    window_size: Option<(u32, u32)>,
+    pub window_size: Option<(u32, u32)>,
     /// Launch the browser with a specific debugging port.
     #[builder(default = "None")]
-    port: Option<u16>,
+    pub port: Option<u16>,
 
     /// Path for Chrome or Chromium.
     ///
     /// If unspecified, the create will try to automatically detect a suitable binary.
     #[builder(default = "None")]
-    path: Option<std::path::PathBuf>,
+    pub path: Option<std::path::PathBuf>,
 
     /// A list of Chrome extensions to load.
     ///
@@ -87,7 +87,7 @@ pub struct LaunchOptions<'a> {
     /// Note that Chrome does not support loading extensions in headless-mode.
     /// See https://bugs.chromium.org/p/chromium/issues/detail?id=706008#c5
     #[builder(default)]
-    extensions: Vec<&'a OsStr>,
+    pub extensions: Vec<&'a OsStr>,
 
     /// The options to use for fetching a version of chrome when `path` is None.
     ///
@@ -106,6 +106,21 @@ pub struct LaunchOptions<'a> {
     /// Passes value through to std::process::Command::envs.
     #[builder(default = "None")]
     pub process_envs: Option<HashMap<String, String>>,
+}
+
+impl<'a> Default for LaunchOptions<'a> {
+    fn default() -> Self {
+        LaunchOptions {
+            headless: true,
+            sandbox: true,
+            idle_browser_timeout: Duration::from_secs(300),
+            window_size: None,
+            path: None,
+            port: None,
+            extensions: Vec::new(),
+            process_envs: None,
+        }
+    }
 }
 
 impl<'a> LaunchOptions<'a> {

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
+use std::time::Duration;
 
 use failure::{Fail, Fallible};
 use log::*;
@@ -13,8 +13,12 @@ use crate::protocol::runtime;
 mod box_model;
 
 use crate::protocol::runtime::methods::RemoteObjectType;
+use crate::util;
 pub use box_model::{BoxModel, ElementQuad};
 
+#[derive(Debug, Fail)]
+#[fail(display = "Couldnt get element quad")]
+pub struct NoQuadFound {}
 /// A handle to a [DOM Element](https://developer.mozilla.org/en-US/docs/Web/API/Element).
 ///
 /// Typically you get access to these by passing `Tab.wait_for_element` a CSS selector. Once
@@ -337,38 +341,65 @@ impl<'a> Element<'a> {
     }
 
     pub fn get_midpoint(&self) -> Fallible<Point> {
-        let return_object = self.parent.call_method(dom::methods::GetContentQuads {
-            node_id: None,
-            backend_node_id: Some(self.backend_node_id),
-            object_id: None,
-        })?;
-        let raw_quad = return_object.quads.first().unwrap();
-        let input_quad = ElementQuad::from_raw_points(&raw_quad);
+        match self
+            .parent
+            .call_method(dom::methods::GetContentQuads {
+                node_id: None,
+                backend_node_id: Some(self.backend_node_id),
+                object_id: None,
+            })
+            .and_then(|quad| {
+                let raw_quad = quad.quads.first().unwrap();
+                let input_quad = ElementQuad::from_raw_points(&raw_quad);
 
-        Ok((input_quad.bottom_right + input_quad.top_left) / 2.0)
+                Ok((input_quad.bottom_right + input_quad.top_left) / 2.0)
+            }) {
+            Ok(e) => return Ok(e),
+            Err(_) => {
+                let mut p = Point { x: 0.0, y: 0.0 };
+
+                util::Wait::with_sleep(Duration::from_secs(1)).run_until(|| {
+                    let r = self.call_js_fn(
+                        r#"
+                    function() {
+                        let v = document.getElementsByClassName("ShowAllChapters")[0];
+
+                        let rect = v.getBoundingClientRect();
+
+                        if(rect.x != 0) {
+                            v.scrollIntoView();
+                        }
+
+                        return v.getBoundingClientRect();
+                    }
+                    "#,
+                        false,
+                    ).unwrap();
+
+                    let res = util::extract_midpoint(r);
+
+                    match res {
+                        Ok(v) => {
+                            if v.x != 0.0 {
+                                p = v;
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        _ => false
+                    }
+                });
+            
+                return Ok(p);
+            }
+        }
     }
 
     pub fn get_js_midpoint(&self) -> Fallible<Point> {
-        let result =
-            self.call_js_fn("function(){ return this.getBoundingClientRect(); }", false)?;
+        let result = self.call_js_fn("function(){return this.getBoundingClientRect(); }", false)?;
 
-        let properties = result
-            .preview
-            .expect("JS couldn't give us quad for element")
-            .properties;
-
-        let mut prop_map = HashMap::new();
-
-        for prop in properties {
-            prop_map.insert(prop.name, prop.value.unwrap().parse::<f64>().unwrap());
-        }
-
-        let midpoint = Point {
-            x: prop_map["x"] + (prop_map["width"] / 2.0),
-            y: prop_map["y"] + (prop_map["height"] / 2.0),
-        };
-
-        Ok(midpoint)
+       util::extract_midpoint(result)
     }
 }
 
@@ -377,3 +408,4 @@ impl<'a> Element<'a> {
 struct ScrollFailed {
     error_text: String,
 }
+

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -27,7 +27,7 @@ use std::thread::sleep;
 
 pub mod element;
 mod keys;
-mod point;
+pub mod point;
 
 #[derive(Debug)]
 pub enum RequestInterceptionDecision {

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -58,6 +58,13 @@ pub type ResponseHandler = Box<
     + Sync,
 >;
 
+
+pub struct SyncSendEvent(pub Arc<Tab>,pub Box<dyn Fn(&Event,&Tab)>);
+
+unsafe impl Sync for SyncSendEvent {}
+
+unsafe impl Send for SyncSendEvent {}
+
 pub trait EventListener<T> {
     fn on_event(&self, event: &T) -> ();
 }
@@ -68,7 +75,15 @@ impl<T, F: Fn(&T) + Send + Sync> EventListener<T> for F {
     }
 }
 
-type SyncSendEvent = dyn EventListener<Event> + Send + Sync;
+impl SyncSendEvent {
+
+    pub fn on_event(&self,event: &Event) {
+        self.1(event,&self.0);
+    }
+
+}
+
+// type SyncSendEvent = dyn EventListener<Event> + Send + Sync;
 
 /// A handle to a single page. Exposes methods for simulating user actions (clicking,
 /// typing), and also for getting information about the DOM and other parts of the page.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,11 @@
-use std::thread::sleep;
 use std::time::{Duration, Instant};
+use std::{collections::HashMap, thread::sleep};
 
 use failure::{Error, Fail, Fallible};
+
+use crate::protocol::runtime::methods::RemoteObject;
+
+use crate::browser::tab::point::Point;
 
 #[derive(Debug, Fail)]
 #[fail(display = "The event waited for never came")]
@@ -20,6 +24,25 @@ impl Default for Wait {
             timeout: Duration::from_secs(10),
             sleep: Duration::from_millis(100),
         }
+    }
+}
+
+pub fn extract_midpoint(remote_obj: RemoteObject) -> Fallible<Point> {
+    let mut prop_map = HashMap::new();
+
+    match remote_obj.preview.and_then(|v| {
+        for prop in v.properties {
+            prop_map.insert(prop.name, prop.value.unwrap().parse::<f64>().unwrap());
+        }
+        let midpoint = Point {
+            x: prop_map["x"] + (prop_map["width"] / 2.0),
+            y: prop_map["y"] + (prop_map["height"] / 2.0),
+        };
+
+        Some(midpoint)
+    }) {
+        Some(v) => return Ok(v),
+        None => return Ok(Point { x: 0.0, y: 0.0 }),
     }
 }
 
@@ -70,6 +93,20 @@ impl Wait {
         }
     }
 
+    pub fn run_until<F>(&self, predicate: F)
+    where
+        F: FnMut() -> bool,
+    {
+        let mut predicate = predicate;
+
+        loop {
+            if predicate() {
+                break;
+            }
+            sleep(self.sleep);
+        }
+    }
+
     /// Wait until the given predicate returns `Ok(G)`, an unexpected error occurs or timeout arrives.
     ///
     /// Errors produced by the predicate are downcasted by the additional provided closure.
@@ -101,3 +138,4 @@ impl Wait {
         }
     }
 }
+


### PR DESCRIPTION
# Changes

https://github.com/atroche/rust-headless-chrome/commit/a93a0e2ac89da641ad73850115459bc8e22e8789 - i made LaunchOptions public and added access of tab in event closure

https://github.com/atroche/rust-headless-chrome/commit/a14d61d48a53912b0a66bafff5ca831c238fb66c - on low speed networks sometimes the dom renders very late, because of this it cant find midpoints to click on the element. so i added functionality to extract midpoints after failure.