### PR TITLE
Remove unused imports to pass clippy tests

### DIFF
--- a/examples/call_js_function_with_args.rs
+++ b/examples/call_js_function_with_args.rs
@@ -2,8 +2,6 @@ use failure::Fallible;
 
 use headless_chrome::{Browser, LaunchOptions};
 
-use serde_json::json;
-
 fn main() -> Fallible<()> {
     let browser = Browser::new(
         LaunchOptions::default_builder()

--- a/examples/settings_and_event.rs
+++ b/examples/settings_and_event.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use failure::Fallible;
 
-use headless_chrome::{Browser, LaunchOptions, Tab, protocol::Event};
+use headless_chrome::{Browser, LaunchOptions, protocol::Event};
 
 fn start() -> Fallible<()> {
     let browser = Browser::new(LaunchOptions {

--- a/tests/expose_function.rs
+++ b/tests/expose_function.rs
@@ -23,7 +23,7 @@ fn expose_function() -> Fallible<()> {
 
     tab.expose_function(
         "simple",
-        Box::new(move |value| {
+        Box::new(move |_value| {
             *function_called_entries_clone.lock().unwrap() += 1;
         }),
     )?;


### PR DESCRIPTION
This PR removes some unused imports and prefixes an unused variable with an underscore. Purpose of these changes is to get rid of the associated compiler warnings.