### PR TITLE
Fix broken imports

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -10,7 +10,7 @@ use failure::{Error, Fail, Fallible};
 use log::*;
 
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::{json, Value as Json};
 
 use element::Element;
@@ -31,7 +31,7 @@ use crate::browser::transport::Transport;
 use crate::protocol::fetch::events::RequestPausedEvent;
 use crate::protocol::fetch::methods::{AuthChallengeResponse, ContinueRequest};
 use crate::protocol::network::methods::SetExtraHTTPHeaders;
-use crate::protocol::network::{Cookie, CookieParam};
+use crate::protocol::network::Cookie;
 use std::thread::sleep;
 
 pub mod element;

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -9,7 +9,6 @@ use std::{
 use failure::{Error, Fail, Fallible};
 use log::*;
 
-use serde::__private::ser;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as Json};


### PR DESCRIPTION
This PR removes an unresolvable import that prevents the latest master from building:
```
error[E0432]: unresolved import `serde::__private`
  --> src/browser/tab/mod.rs:12:12
   |
12 | use serde::__private::ser;
   |            ^^^^^^^^^ could not find `__private` in `serde`
```

It also removes those two unused imports:
```
warning: unused import: `Deserialize`
  --> src/browser/tab/mod.rs:14:13
   |
14 | use serde::{Deserialize, Serialize};
   |             ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `CookieParam`
  --> src/browser/tab/mod.rs:35:40
   |
35 | use crate::protocol::network::{Cookie, CookieParam};
   |                                        ^^^^^^^^^^^
```