### PR TITLE
Feat set background color

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -867,7 +867,7 @@ impl Tab {
     /// use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptions};
     /// let browser = Browser::new(LaunchOptions::default_builder().build().unwrap())?;
     /// let tab = browser.wait_for_initial_tab()?;
-    /// tab.set_background_color( color: RGBA { r: 0, g: 0, b: 0, a: 0.,})?;
+    /// tab.set_transparent_background_color()?;
     ///
     /// #
     /// # Ok(())
@@ -876,10 +876,10 @@ impl Tab {
     pub fn set_transparent_background_color(&self) -> Fallible<&Self> {
         self.call_method(page::methods::SetDefaultBackgroundColorOverride {
             color: protocol::dom::RGBA {
-                r: 255,
+                r: 0,
                 g: 0,
                 b: 0,
-                a: 1.,
+                a: 0.,
             },
         })?;
         Ok(self)
@@ -896,7 +896,7 @@ impl Tab {
     /// use headless_chrome::{protocol::page::ScreenshotFormat, Browser, LaunchOptions};
     /// let browser = Browser::new(LaunchOptions::default_builder().build().unwrap())?;
     /// let tab = browser.wait_for_initial_tab()?;
-    /// tab.set_transparent_background_color()?;
+    /// tab.set_background_color( color: RGBA { r: 255, g: 0, b: 0, a: 1.,})?;
     ///
     /// #
     /// # Ok(())

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -876,10 +876,10 @@ impl Tab {
     pub fn set_transparent_background_color(&self) -> Fallible<&Self> {
         self.call_method(page::methods::SetDefaultBackgroundColorOverride {
             color: protocol::dom::RGBA {
-                r: 0,
+                r: 255,
                 g: 0,
                 b: 0,
-                a: 0.,
+                a: 1.,
             },
         })?;
         Ok(self)

--- a/src/protocol/dom.rs
+++ b/src/protocol/dom.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use crate::protocol::types::JsUInt;
-use serde::{Deserialize, Deserializer};
+use crate::protocol::types::{JsUInt,JsFloat};
+use serde::{Serialize,Deserialize, Deserializer};
 
 use super::types::UniqueSessionId;
 
@@ -10,6 +10,15 @@ pub type NodeId = JsUInt;
 pub type SearchId = UniqueSessionId;
 
 pub type NodeAttributes = HashMap<String, String>;
+
+#[derive(Serialize,Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RGBA {
+  r: JsUInt,
+  g: JsUInt,
+  b: JsUInt,
+  a: JsFloat,
+}
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/protocol/dom.rs
+++ b/src/protocol/dom.rs
@@ -14,10 +14,10 @@ pub type NodeAttributes = HashMap<String, String>;
 #[derive(Serialize,Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RGBA {
-  r: JsUInt,
-  g: JsUInt,
-  b: JsUInt,
-  a: JsFloat,
+  pub r: JsUInt,
+  pub g: JsUInt,
+  pub b: JsUInt,
+  pub a: JsFloat,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/protocol/page.rs
+++ b/src/protocol/page.rs
@@ -130,6 +130,7 @@ pub mod methods {
     use serde::{Deserialize, Serialize};
 
     use crate::protocol::Method;
+    use crate::protocol::dom::RGBA;
 
     use super::PrintToPdfOptions;
     use crate::protocol::types::JsUInt;
@@ -309,5 +310,18 @@ pub mod methods {
     impl Method for AddScriptToEvaluateOnNewDocument {
         const NAME: &'static str = "Page.addScriptToEvaluateOnNewDocument";
         type ReturnObject = AddScriptToEvaluateOnNewDocumentReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetDefaultBackgroundColorOverride {
+        color: RGBA,
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct SetDefaultBackgroundColorOverrideReturnObject {}
+    impl Method for SetDefaultBackgroundColorOverride {
+        const NAME: &'static str = "Emulation.setDefaultBackgroundColorOverride";
+        type ReturnObject = SetDefaultBackgroundColorOverrideReturnObject;
     }
 }

--- a/src/protocol/page.rs
+++ b/src/protocol/page.rs
@@ -315,7 +315,7 @@ pub mod methods {
     #[derive(Serialize, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct SetDefaultBackgroundColorOverride {
-        color: RGBA,
+        pub color: RGBA,
     }
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]

--- a/tests/transparent.html
+++ b/tests/transparent.html
@@ -1,0 +1,17 @@
+<html>
+
+<head>
+    <style type="text/css">
+        body {
+            width:500px;
+            height:800px;
+        }
+
+    </style>
+</head>
+
+<body>
+
+</body>
+
+</html>


### PR DESCRIPTION
From Chrome API: 
https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDefaultBackgroundColorOverride

I propose the integration of two functions: 
- set_transparent_background_color
- set_background_color

I find this very useful when you use chrome headless for some rendering in png. 
This feature of transparency exist with Puppeteer (know as the option : 'omitBackground', when you take a capture). 

Doc:
![image](https://user-images.githubusercontent.com/6035442/123295905-7393e080-d516-11eb-814b-ccfd85e8cbbd.png)
