### PR TITLE
Feat: add method to get CSS styles from element

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -18,7 +18,7 @@ use crate::browser::context::Context;
 use crate::protocol::browser::methods::GetVersion;
 pub use crate::protocol::browser::methods::VersionInformationReturnObject;
 use crate::protocol::target::methods::{CreateTarget, SetDiscoverTargets};
-use crate::protocol::{self, Event};
+use crate::protocol::{self, css, Event};
 use crate::util;
 
 #[cfg(feature = "fetch")]
@@ -154,9 +154,10 @@ impl Browser {
         trace!("Calling set discover");
         browser.call_method(SetDiscoverTargets { discover: true })?;
 
-        browser
-            .wait_for_initial_tab()?
-            .call_method(methods::Enable {})?;
+        let tab = browser.wait_for_initial_tab()?;
+
+        tab.call_method(methods::Enable {})?;
+        tab.call_method(css::methods::Enable {})?;
 
         Ok(browser)
     }

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -6,6 +6,8 @@ use log::*;
 
 use crate::browser::tab::point::Point;
 use crate::browser::tab::NoElementFound;
+use crate::protocol::css;
+use crate::protocol::css::ComputedStyleProperty;
 use crate::protocol::dom;
 use crate::protocol::page;
 use crate::protocol::runtime;
@@ -394,6 +396,17 @@ impl<'a> Element<'a> {
             })?
             .node;
         Ok(node)
+    }
+
+    pub fn get_computed_styles(&self) -> Fallible<Vec<ComputedStyleProperty>> {
+        let styles = self
+            .parent
+            .call_method(css::methods::GetComputedStyleForNode {
+                node_id: self.node_id,
+            })?
+            .computed_style;
+
+        Ok(styles)
     }
 
     /// Capture a screenshot of this element.

--- a/src/protocol/css.rs
+++ b/src/protocol/css.rs
@@ -1,0 +1,46 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ComputedStyleProperty {
+    pub name: String,
+    pub value: String,
+}
+
+pub mod methods {
+
+    use crate::protocol::{types::JsUInt, Method};
+
+    pub type NodeId = JsUInt;
+
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct GetComputedStyleForNode {
+        pub node_id: NodeId,
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct GetComputedStyleForNodeReturnObject {
+        pub computed_style: Vec<super::ComputedStyleProperty>,
+    }
+
+    impl<'a> Method for GetComputedStyleForNode {
+        const NAME: &'static str = "CSS.getComputedStyleForNode";
+        type ReturnObject = GetComputedStyleForNodeReturnObject;
+    }
+
+    #[derive(Serialize, Debug)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Enable {}
+
+    #[derive(Debug, Deserialize)]
+    pub struct EnableReturnObject {}
+
+    impl Method for Enable {
+        const NAME: &'static str = "CSS.enable";
+
+        type ReturnObject = EnableReturnObject;
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -19,6 +19,7 @@ pub mod profiler;
 pub mod runtime;
 pub mod target;
 pub mod types;
+pub mod css;
 
 /// Browser window Id
 type WindowId = JsUInt;


### PR DESCRIPTION
Implemented method `get_computed_styles' on the Element struct which returns array of CSS styles.