### PR TITLE
fix ignore_certificate_errors flag, idle_browser_timeout, process stderr handle

### DIFF
--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -231,6 +231,9 @@ impl Process {
             attempts += 1;
         }
 
+        let mut child = process.0.borrow_mut();
+        child.stderr = None;
+
         Ok(Self {
             child_process: process,
             debug_ws_url: url,

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -119,7 +119,7 @@ pub struct LaunchOptions<'a> {
 
     /// How long to keep the WebSocket to the browser for after not receiving any events from it
     /// Defaults to 30 seconds
-    #[builder(default = "Duration::from_secs(300)")]
+    #[builder(default = "Duration::from_secs(30)")]
     pub idle_browser_timeout: Duration,
 
     /// Environment variables to set for the Chromium process.
@@ -133,7 +133,7 @@ impl<'a> Default for LaunchOptions<'a> {
         LaunchOptions {
             headless: true,
             sandbox: true,
-            idle_browser_timeout: Duration::from_secs(300),
+            idle_browser_timeout: Duration::from_secs(30),
             window_size: None,
             path: None,
             user_data_dir: None,

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -297,7 +297,7 @@ impl Process {
             args.extend(&["--headless"]);
         }
 
-        if !launch_options.ignore_certificate_errors {
+        if launch_options.ignore_certificate_errors {
             args.extend(&["--ignore-certificate-errors"])
         }
 


### PR DESCRIPTION
The logic to enable the option was invalid.