### PR TITLE
Fix ResourceType naming for XHR and CSPViolationReport

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -9244,6 +9244,7 @@ pub mod cdp {
             Font,
             Script,
             TextTrack,
+            #[serde(rename = "XHR")]
             Xhr,
             Fetch,
             EventSource,
@@ -9251,6 +9252,7 @@ pub mod cdp {
             Manifest,
             SignedExchange,
             Ping,
+            #[serde(rename = "CSPViolationReport")]
             CspViolationReport,
             Preflight,
             Other,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -9244,16 +9244,14 @@ pub mod cdp {
             Font,
             Script,
             TextTrack,
-            #[serde(rename = "XHR")]
-            Xhr,
+            XHR,
             Fetch,
             EventSource,
             WebSocket,
             Manifest,
             SignedExchange,
             Ping,
-            #[serde(rename = "CSPViolationReport")]
-            CspViolationReport,
+            CSPViolationReport,
             Preflight,
             Other,
         }


### PR DESCRIPTION
XHR and CSPViolationReport are not strict PascalCase. Should add a special case renaming to avoid failure.

Renaming enum to `XHR` and `CSPViolationReport` seems more consistent. I think it would be "backward-compatible" since there is no one reporting this bug : /

[ResourceType on ChromeDev Protocol manual](https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType), 