### PR TITLE
Created `send_character` method as a much faster alternative to `type_str`

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -801,10 +801,11 @@ impl Tab {
         Ok(self)
     }
 
-    /// Dispatches a `keypress` and `input` event.
-    /// This does not send a `keydown` or `keyup` event.
+    /// Does the same as `type_str` but it only dispatches a `keypress` and `input` event.
+    /// It does not send a `keydown` or `keyup` event.
     ///
-    /// Useful when you have a lot of text to input. With this method it is instant
+    /// What this means is that it is much faster. 
+    /// It is especially useful when you have a lot of text as input.
     pub fn send_character(&self, char_to_send: &str) -> Result<&Self> {
         self.call_method(Input::InsertText {
             text: char_to_send.to_string(),

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -794,12 +794,21 @@ impl Tab {
                     })?;
                 }
                 Err(_) => {
-                    self.call_method(Input::InsertText {
-                        text: c.to_string(),
-                    })?;
+                    self.send_character(c)?;
                 }
             }
         }
+        Ok(self)
+    }
+
+    /// Dispatches a `keypress` and `input` event.
+    /// This does not send a `keydown` or `keyup` event.
+    ///
+    /// Useful when you have a lot of text to input. With this method it is instant
+    pub fn send_character(&self, char_to_send: &str) -> Result<&Self> {
+        self.call_method(Input::InsertText {
+            text: char_to_send.to_string(),
+        })?;
         Ok(self)
     }
 

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -180,6 +180,21 @@ fn form_interaction() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn send_character() -> Result<()> {
+    logging::enable_logging();
+    let (_, browser, tab) = dumb_server(include_str!("form.html"));
+    tab.find_element("input#target")?.click()?;
+    tab.send_character("mothership")?;
+    tab.find_element("button")?.click()?;
+    let d = tab.wait_for_element("div#protocol")?.get_description()?;
+    assert!(d
+        .find(|n| n.node_value == "Missiles launched against mothership")
+        .is_some());
+    
+    Ok(())
+}
+
 fn decode_png(i: &[u8]) -> Result<Vec<u8>> {
     let decoder = png::Decoder::new(&i[..]);
     let (info, mut reader) = decoder.read_info()?;


### PR DESCRIPTION
In addition to `type`, puppeteer also has this method for text input: [`sendCharacter`](https://github.com/puppeteer/puppeteer/blob/ce0dd25349b3141409cf68121a2bf9a770d9ecf7/src/common/Input.ts#L243)

What this does is it just passes the provided input text to the `Input::InsertText` method without any processing. This is very useful because when we have a lot of text, the normal `type` (or `type_str` in our case) method takes a very long time. The `sendCharacter` method does it instantly.

### Changes

1. Created the `send_character` method.
2. Changed `type_str` so now it uses the new `send_character` method instead of calling `Input::InsertText` directly. No real reason for this change, but I think it makes the code a little more organized.

<br>

_Note: I'm not very happy with neither the method name "send_character" nor the parameter name "char_to_send". We should definitely find better names because even thought there is documentation, I believe the method name should give to the developer some idea of what it does._

This is the documentation I made: (copied from puppeteer docs)
![Screenshot from 2022-06-17 16-21-51](https://user-images.githubusercontent.com/50553687/174306697-fc61bb61-26af-41ba-8e4c-0b21b4be872a.png)