### PR TITLE
Created methods to get full HTML from page and elements

### DIFF
--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -352,6 +352,18 @@ impl<'a> Element<'a> {
         Ok(text)
     }
 
+    /// Get the full HTML contents of the element.
+    /// 
+    /// Equivalent to the following JS: ```element.outerHTML```.
+    pub fn get_content(&self) -> Result<String> {
+        let html = self.
+                call_js_fn("function() { return this.outerHTML }", vec![], false)?
+                    .value
+                    .unwrap();
+
+        Ok(String::from(html.as_str().unwrap()))
+    }
+
     pub fn get_computed_styles(&self) -> Result<Vec<CSSComputedStyleProperty>> {
         let styles = self
             .parent

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -718,6 +718,17 @@ impl Tab {
             .root)
     }
 
+    /// Get the full HTML contents of the page.
+    /// 
+    /// Equivalent to the following JS: ```document.documentElement.outerHTML```
+    pub fn get_content(&self) -> Result<String> {
+        let html = self
+            .evaluate("(function () { return document.documentElement.outerHTML })();", false)?
+                .value
+                .unwrap();
+        Ok(String::from(html.as_str().unwrap()))
+    }
+
     pub fn find_elements(&self, selector: &str) -> Result<Vec<Element<'_>>> {
         trace!("Looking up elements via selector: {}", selector);
 

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -719,11 +719,18 @@ impl Tab {
     }
 
     /// Get the full HTML contents of the page.
-    /// 
-    /// Equivalent to the following JS: ```document.documentElement.outerHTML```
     pub fn get_content(&self) -> Result<String> {
+        let func = "
+            (function () { 
+                let retVal = '';
+                if (document.doctype)
+                    retVal = new XMLSerializer().serializeToString(document.doctype);
+                if (document.documentElement)
+                    retVal += document.documentElement.outerHTML;
+                return retVal;
+            })();";
         let html = self
-            .evaluate("(function () { return document.documentElement.outerHTML })();", false)?
+            .evaluate(func, false)?
                 .value
                 .unwrap();
         Ok(String::from(html.as_str().unwrap()))

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -195,6 +195,28 @@ fn send_character() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn tab_get_content() -> Result<()> {
+    logging::enable_logging();
+    let (_, browser, tab) = dumb_server(include_str!("simple.html"));
+    let html = tab.get_content()?;
+    // The html returned depends on how the browser formatted it. The HTML is always correct, but 
+    // some of the newlines or tabs might be missing.
+    assert!(html.replace("\n", "") == include_str!("simple.html").replace("\n", ""));
+    Ok(())
+}
+
+#[test]
+fn element_get_content() -> Result<()> {
+    logging::enable_logging();
+    let (_, browser, tab) = dumb_server(include_str!("simple.html"));
+    let elem = tab.find_element("div#within")?;
+    let html = elem.get_content()?;
+    assert!(html == r#"<div id="within"></div>"#);
+    Ok(())
+}
+
+
 fn decode_png(i: &[u8]) -> Result<Vec<u8>> {
     let decoder = png::Decoder::new(&i[..]);
     let (info, mut reader) = decoder.read_info()?;


### PR DESCRIPTION
Adds two new methods for get the full HTML contents of a tab or a selected element.

The String returned by `tab.get_content()` can be parsed by [scraper](https://crates.io/crates/scraper) with the method `scraper::Html::parse_document`. 
The String returned by `elem.get_content()` can be parsed by [scraper](https://crates.io/crates/scraper) with the method `scraper::Html::parse_fragment`.

The way it gets the HTML is by running a JS function. I don't know if this is the best way to do it, but I can't think of any other way.