### PR TITLE
Added `microsoft-edge` to list of bins to look for

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -442,6 +442,7 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
         "chrome",
         "chrome-browser",
         "msedge",
+        "microsoft-edge"
     ] {
         if let Ok(path) = which(app) {
             return Ok(path);


### PR DESCRIPTION
Added another entry for microsoft edge to autodetect with.

The binary name for msedge on some OS's (some linux distros namely such as Silverblue) is `microsoft-edge`.