### PR TITLE
build: Add feature for enabling rustls in deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,14 @@ jpeg-decoder = { version = "0.1", default_features = false }
 filepath = "0.1.1"
 
 [build-dependencies]
-auto_generate_cdp = "0.3.3"
+auto_generate_cdp = { version = "0.3.3", default-features = false }
 
 [lib]
 name = "headless_chrome"
 path = "src/lib.rs"
 
 [features]
-default = []
+default = [ "auto_generate_cdp/native-tls" ]
 fetch = [ "ureq", "directories", "zip", "walkdir" ]
+rustls = [ "auto_generate_cdp/rustls" ]
 nightly = []


### PR DESCRIPTION
If any downstream crates are using rustls, they will potentially have issues since the current `auto_generate_cdp/reqwest` dependency uses the `native-tls` default feature. This change would allow for this to be toggled.

Requires https://github.com/mdrokz/auto_generate_cdp/pull/2 to be merged.

Signed-off-by: Sean Pianka <pianka@eml.cc>