### PR TITLE
migrate websocket to tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ tempfile = "3"
 thiserror = '1'
 ureq = { version = "2.5", optional = true }
 walkdir = { version = "2", optional = true }
-websocket = { version = "0.26", default_features = false, features = ["sync"] }
+tungstenite = "0.18"
+url = "2.3"
 which = "4.0"
 zip = { version = "0.6.3", optional = true }
 
@@ -48,3 +49,5 @@ path = "src/lib.rs"
 [features]
 fetch = ["ureq", "directories", "zip", "walkdir"]
 nightly = []
+rustls = ["tungstenite/rustls"]
+native-tls = ["tungstenite/native-tls"]

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -12,7 +12,7 @@ pub use process::{LaunchOptions, LaunchOptionsBuilder, DEFAULT_ARGS};
 pub use tab::Tab;
 pub use transport::ConnectionClosed;
 use transport::Transport;
-use websocket::url::Url;
+use url::Url;
 use which::which;
 
 use crate::protocol::cdp::{types::Event, types::Method, Browser as B, Target, CSS, DOM};

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -16,7 +16,7 @@ use rand::seq::SliceRandom;
 use rand::thread_rng;
 use regex::Regex;
 use thiserror::Error;
-use websocket::url::Url;
+use url::Url;
 #[cfg(windows)]
 use winreg::{enums::HKEY_LOCAL_MACHINE, RegKey};
 

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -13,9 +13,9 @@ use thiserror::Error;
 
 use log::{error, info, trace, warn};
 
+use url::Url;
 use waiting_call_registry::WaitingCallRegistry;
 use web_socket_connection::WebSocketConnection;
-use websocket::url::Url;
 
 use crate::protocol::cdp::{types::Event, types::Method, Target};
 
@@ -263,7 +263,6 @@ impl Transport {
                         break;
                     }
                     Ok(message) => {
-                        //                        trace!("{:?}", message);
                         match message {
                             Message::ConnectionShutdown => {
                                 info!("Received shutdown message");

--- a/src/browser/transport/web_socket_connection.rs
+++ b/src/browser/transport/web_socket_connection.rs
@@ -1,18 +1,23 @@
+use std::net::TcpStream;
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::sync::Mutex;
 
 use anyhow::Result;
 use log::{debug, info, trace, warn};
-use websocket::client::sync::Client;
-use websocket::stream::sync::TcpStream;
-use websocket::url::Url;
-use websocket::WebSocketError;
-use websocket::{ClientBuilder, OwnedMessage};
+use tungstenite::http::Response;
+use tungstenite::stream::MaybeTlsStream;
+use url::Url;
 
 use crate::types::{parse_raw_message, Message};
 
+type TungsteniteWebsocketConnection = tungstenite::protocol::WebSocket<MaybeTlsStream<TcpStream>>;
+
+const READ_TIMEOUT_DURATION: std::time::Duration = std::time::Duration::from_millis(100);
+
 pub struct WebSocketConnection {
-    sender: Mutex<websocket::sender::Writer<TcpStream>>,
+    connection: Arc<Mutex<TungsteniteWebsocketConnection>>,
+    thread: std::thread::JoinHandle<()>,
     process_id: Option<u32>,
 }
 
@@ -29,17 +34,22 @@ impl WebSocketConnection {
         process_id: Option<u32>,
         messages_tx: mpsc::Sender<Message>,
     ) -> Result<Self> {
-        let connection = Self::websocket_connection(ws_url)?;
-        let (websocket_receiver, sender) = connection.split()?;
+        let (connection, _) = Self::websocket_connection(ws_url)?;
 
-        std::thread::spawn(move || {
-            trace!("Starting msg dispatching loop");
-            Self::dispatch_incoming_messages(websocket_receiver, messages_tx, process_id);
-            trace!("Quit loop msg dispatching loop");
-        });
+        let connection = Arc::new(Mutex::new(connection));
+
+        let thread = {
+            let sender = connection.clone();
+            std::thread::spawn(move || {
+                trace!("Starting msg dispatching loop");
+                Self::dispatch_incoming_messages(sender, messages_tx, process_id);
+                trace!("Quit loop msg dispatching loop");
+            })
+        };
 
         Ok(Self {
-            sender: Mutex::new(sender),
+            connection,
+            thread,
             process_id,
         })
     }
@@ -49,37 +59,52 @@ impl WebSocketConnection {
             "Shutting down WebSocket connection for Chrome {:?}",
             self.process_id
         );
-        if self.sender.lock().unwrap().shutdown_all().is_err() {
+        if let Err(err) = self.connection.lock().unwrap().close(None) {
             debug!(
-                "Couldn't shut down WS connection for Chrome {:?}",
-                self.process_id
+                "Couldn't shut down WS connection for Chrome {:?}: {}",
+                self.process_id, err
             );
         }
+
+        self.connection.lock().unwrap().write_pending().ok();
+        self.thread.thread().unpark();
     }
 
     fn dispatch_incoming_messages(
-        mut receiver: websocket::receiver::Reader<TcpStream>,
+        receiver: Arc<Mutex<TungsteniteWebsocketConnection>>,
         messages_tx: mpsc::Sender<Message>,
         process_id: Option<u32>,
     ) {
-        for ws_message in receiver.incoming_messages() {
-            match ws_message {
-                Err(error) => match error {
-                    WebSocketError::NoDataAvailable => {
-                        debug!("WS Error Chrome #{:?}: {}", process_id, error);
-                        break;
+        loop {
+            let message = receiver.lock().unwrap().read_message();
+
+            match message {
+                Err(err) => match err {
+                    tungstenite::Error::Io(err) => {
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) {
+                            std::thread::park_timeout(READ_TIMEOUT_DURATION);
+                        } else {
+                            debug!("WS IO Error for Chrome #{:?}: {}", process_id, err);
+                            break;
+                        }
                     }
-                    WebSocketError::IoError(err) => {
-                        debug!("WS IO Error for Chrome #{:?}: {}", process_id, err);
-                        break;
+                    tungstenite::Error::ConnectionClosed
+                    | tungstenite::Error::AlreadyClosed
+                    | tungstenite::Error::Protocol(
+                        tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+                    ) => break,
+                    error => {
+                        panic!(
+                            "Unhandled WebSocket error for Chrome #{:?}: {:?}",
+                            process_id, error
+                        );
                     }
-                    _ => panic!(
-                        "Unhandled WebSocket error for Chrome #{:?}: {:?}",
-                        process_id, error
-                    ),
                 },
                 Ok(message) => {
-                    if let OwnedMessage::Text(message_string) = message {
+                    if let tungstenite::protocol::Message::Text(message_string) = message {
                         if let Ok(message) = parse_raw_message(&message_string) {
                             if messages_tx.send(message).is_err() {
                                 break;
@@ -103,8 +128,27 @@ impl WebSocketConnection {
         }
     }
 
-    pub fn websocket_connection(ws_url: &Url) -> Result<Client<TcpStream>> {
-        let client = ClientBuilder::from_url(ws_url).connect_insecure()?;
+    pub fn websocket_connection(
+        ws_url: &Url,
+    ) -> Result<(
+        tungstenite::WebSocket<MaybeTlsStream<TcpStream>>,
+        Response<Option<Vec<u8>>>,
+    )> {
+        let mut client = tungstenite::connect(ws_url)?;
+
+        let stream = client.0.get_mut();
+
+        // this should be handled in tungstenite
+        let stream = match stream {
+            MaybeTlsStream::Plain(s) => s,
+            #[cfg(features = "native-tls")]
+            MaybeTlsStream::NativeTls(s) => s.get_mut(),
+            #[cfg(features = "rustls")]
+            MaybeTlsStream::Rustls(s) => &mut s.sock,
+
+            _ => todo!(),
+        };
+        stream.set_read_timeout(Some(READ_TIMEOUT_DURATION))?;
 
         debug!("Successfully connected to WebSocket: {}", ws_url);
 
@@ -112,9 +156,10 @@ impl WebSocketConnection {
     }
 
     pub fn send_message(&self, message_text: &str) -> Result<()> {
-        let message = websocket::Message::text(message_text);
-        let mut sender = self.sender.lock().unwrap();
-        sender.send_message(&message)?;
+        let message = tungstenite::protocol::Message::text(message_text);
+        let mut sender = self.connection.lock().unwrap();
+        sender.write_message(message)?;
+        self.thread.thread().unpark();
         Ok(())
     }
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -220,8 +220,6 @@ fn decode_png(i: &[u8]) -> Result<Vec<u8>> {
     let decoder = png::Decoder::new(i);
     let mut reader = decoder.read_info()?;
     let mut buf = vec![0; reader.output_buffer_size()];
-    let info = reader.next_frame(&mut buf).unwrap();
-    let mut buf = vec![0; info.buffer_size()];
     reader.next_frame(&mut buf)?;
     Ok(buf)
 }


### PR DESCRIPTION
As requested in https://github.com/atroche/rust-headless-chrome/pull/349#issuecomment-1366959108.

the difference between this pr and the referenced pr is that this uses `tungstenite` directly instead of `tokio-tungstenite` so this doesn't pull in async runtime. 

Unlike `websocket` and `tokio-tungstenite`, `tungstenite` doesn't provide split API and mutable reference to WebSocket is required to send and receive messages, so mutex is used. `TcpStream::set_read_timeout` is used to avoid the receiver thread locking the mutex for too long.

This fixes https://github.com/atroche/rust-headless-chrome/issues/322.