### PR TITLE
Fix usage of String::truncate

### DIFF
--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -371,9 +371,11 @@ impl Browser {
                                 }
                             }
                             _ => {
-                                let mut raw_event = format!("{:?}", event);
-                                raw_event.truncate(50);
-                                trace!("Unhandled event: {}", raw_event);
+                                let raw_event = format!("{:?}", event);
+                                trace!(
+                                    "Unhandled event: {}",
+                                    raw_event.chars().take(50).collect::<String>()
+                                );
                             }
                         }
                     }

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -421,9 +421,11 @@ impl Tab {
                         )
                     }
                     _ => {
-                        let mut raw_event = format!("{:?}", event);
-                        raw_event.truncate(50);
-                        trace!("Unhandled event: {}", raw_event);
+                        let raw_event = format!("{:?}", event);
+                        trace!(
+                            "Unhandled event: {}",
+                            raw_event.chars().take(50).collect::<String>()
+                        );
                     }
                 }
             }
@@ -490,9 +492,8 @@ impl Tab {
         let result = self
             .transport
             .call_method_on_target(self.session_id.clone(), method);
-        let mut result_string = format!("{:?}", result);
-        result_string.truncate(70);
-        trace!("Got result: {:?}", result_string);
+        let result_string = format!("{:?}", result);
+        trace!("Got result: {:?}", result_string.chars().take(70));
         result
     }
 

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -44,7 +44,7 @@ use Fetch::{
 };
 
 use Network::{
-    events::ResponseReceivedEventParams, events::LoadingFailedEventParams, Cookie, GetResponseBody, 
+    events::LoadingFailedEventParams, events::ResponseReceivedEventParams, Cookie, GetResponseBody,
     GetResponseBodyReturnObject, SetExtraHTTPHeaders, SetUserAgentOverride,
 };
 
@@ -87,7 +87,6 @@ pub type LoadingFailedHandler = Box<
     ) + Send
     + Sync,
 >;
-
 
 type SyncSendEvent = dyn EventListener<Event> + Send + Sync;
 pub trait RequestInterceptor {
@@ -408,18 +407,18 @@ impl Tab {
                             },
                         );
                     }
-                    Event::NetworkLoadingFailed(ev) => {
-                        loading_failed_handler_mutex.lock().unwrap().iter().for_each(
-                            |(_name, handler)| {
-                                let request_id = ev.params.request_id.clone();
+                    Event::NetworkLoadingFailed(ev) => loading_failed_handler_mutex
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .for_each(|(_name, handler)| {
+                            let request_id = ev.params.request_id.clone();
 
-                                match received_event_params.lock().unwrap().get(&request_id) {
-                                    Some(params) => handler(params.to_owned(), ev.params.to_owned()),
-                                    _ => warn!("Request id does not exist"),
-                                }
+                            match received_event_params.lock().unwrap().get(&request_id) {
+                                Some(params) => handler(params.to_owned(), ev.params.to_owned()),
+                                _ => warn!("Request id does not exist"),
                             }
-                        )
-                    }
+                        }),
                     _ => {
                         let raw_event = format!("{:?}", event);
                         trace!(
@@ -1283,13 +1282,21 @@ impl Tab {
             .insert(handler_name.to_string(), handler))
     }
 
-    pub fn register_loading_failed_handling<S: ToString>(&self, handler_name: S, handler: LoadingFailedHandler) -> Result<Option<LoadingFailedHandler>> {
+    pub fn register_loading_failed_handling<S: ToString>(
+        &self,
+        handler_name: S,
+        handler: LoadingFailedHandler,
+    ) -> Result<Option<LoadingFailedHandler>> {
         self.call_method(Network::Enable {
             max_total_buffer_size: None,
             max_resource_buffer_size: None,
             max_post_data_size: None,
         })?;
-        Ok(self.loading_failed_handler.lock().unwrap().insert(handler_name.to_string(), handler))
+        Ok(self
+            .loading_failed_handler
+            .lock()
+            .unwrap()
+            .insert(handler_name.to_string(), handler))
     }
 
     /// Deregister a reponse handler based on its name.
@@ -1717,9 +1724,10 @@ impl Tab {
 
     fn bypass_wedriver(&self) -> Result<()> {
         self.call_method(Page::AddScriptToEvaluateOnNewDocument {
-            source: "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});".to_string(),
+            source: "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
+                .to_string(),
             world_name: None,
-            include_command_line_api: None
+            include_command_line_api: None,
         })?;
         Ok(())
     }
@@ -1728,7 +1736,7 @@ impl Tab {
         self.call_method(Page::AddScriptToEvaluateOnNewDocument {
             source: "window.chrome = { runtime: {} };".to_string(),
             world_name: None,
-            include_command_line_api: None
+            include_command_line_api: None,
         })?;
         Ok(())
     }
@@ -1743,7 +1751,7 @@ impl Tab {
         self.call_method(Page::AddScriptToEvaluateOnNewDocument {
             source: r.to_string(),
             world_name: None,
-            include_command_line_api: None
+            include_command_line_api: None,
         })?;
         Ok(())
     }
@@ -1754,9 +1762,10 @@ impl Tab {
             {filename:'internal-pdf-viewer'},
             {filename:'adsfkjlkjhalkh'},
             {filename:'internal-nacl-plugin'}
-          ], });".to_string(),
+          ], });"
+                .to_string(),
             world_name: None,
-            include_command_line_api: None
+            include_command_line_api: None,
         })?;
         Ok(())
     }
@@ -1779,7 +1788,7 @@ impl Tab {
         self.call_method(Page::AddScriptToEvaluateOnNewDocument {
             source: r.to_string(),
             world_name: None,
-            include_command_line_api: None
+            include_command_line_api: None,
         })?;
         Ok(())
     }

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -144,9 +144,10 @@ impl Transport {
                     session_id: Some(session_id.0),
                     message,
                 };
-                let mut raw = message_text;
-                raw.truncate(300);
-                trace!("Msg to tab: {}", &raw);
+                trace!(
+                    "Msg to tab: {}",
+                    message_text.chars().take(300).collect::<String>()
+                );
                 if let Err(e) = self.call_method_on_browser(target_method) {
                     warn!("Failed to call method on browser: {:?}", e);
                     self.waiting_call_registry.unregister_call(call.id);
@@ -163,12 +164,11 @@ impl Transport {
             }
         }
 
-        let mut params_string = format!("{:?}", call.get_params());
-        params_string.truncate(400);
+        let params_string = format!("{:?}", call.get_params());
         trace!(
             "waiting for response from call registry: {} {:?}",
             &call_id,
-            params_string
+            params_string.chars().take(400).collect::<String>()
         );
 
         let response_result = util::Wait::new(self.idle_browser_timeout, Duration::from_millis(5))
@@ -322,11 +322,11 @@ impl Transport {
                                         listeners.lock().unwrap().get(&ListenerId::Browser)
                                     {
                                         if let Err(err) = tx.send(browser_event.clone()) {
-                                            let mut event_string = format!("{:?}", browser_event);
-                                            event_string.truncate(400);
+                                            let event_string = format!("{:?}", browser_event);
                                             warn!(
                                                 "Couldn't send browser an event: {:?}\n{:?}",
-                                                event_string, err
+                                                event_string.chars().take(400).collect::<String>(),
+                                                err
                                             );
                                             break;
                                         }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -721,9 +721,19 @@ fn loading_failed_handler() -> Result<()> {
     let failed_event = Arc::new(Mutex::new(Vec::new()));
 
     let failed_event_clone = failed_event.clone();
-    assert_eq!(tab.register_loading_failed_handling("test1",Box::new(move |response, loading_failed| {
-        failed_event_clone.lock().unwrap().push((response, loading_failed))
-    }))?.is_none(), true);
+    assert_eq!(
+        tab.register_loading_failed_handling(
+            "test1",
+            Box::new(move |response, loading_failed| {
+                failed_event_clone
+                    .lock()
+                    .unwrap()
+                    .push((response, loading_failed))
+            })
+        )?
+        .is_none(),
+        true
+    );
 
     tab.navigate_to(&format!("http://127.0.0.1:{}", server.port()))
         .unwrap();
@@ -732,7 +742,10 @@ fn loading_failed_handler() -> Result<()> {
 
     let final_failed_event: Vec<_> = failed_event.lock().unwrap().clone();
     assert_eq!(final_failed_event.len(), 1);
-    assert_eq!(final_failed_event[0].0.response.url, "http://httpbin.org/status/404");
+    assert_eq!(
+        final_failed_event[0].0.response.url,
+        "http://httpbin.org/status/404"
+    );
     assert_eq!(final_failed_event[0].0.response.status, 404);
     assert_eq!(final_failed_event[0].1.error_text, "net::ERR_ABORTED");
 


### PR DESCRIPTION
I got a panic when passing `expression` with multi-byte characters to `browser::tab::Tab::evaluate`.
I found out the problem is wrong usage of `String::truncate`, so this PR replaces these usages to safer method.

e.g.
```rs
// this is fine.
String::from("abcde").truncate(1);
// this panics because character '★' is 2-bytes long, and we can't split it halfway.
String::from("★★★").truncate(1);
```