### PR TITLE
Fix to prevent panic on looping through empty vector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headless_chrome_fork"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Alistair Roche <alistair@sunburnt.country>"]
 edition = "2018"
 description = "Control Chrome programatically"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "headless_chrome"
-version = "0.9.0"
+name = "headless_chrome_fork"
+version = "1.0.0"
 authors = ["Alistair Roche <alistair@sunburnt.country>"]
 edition = "2018"
 description = "Control Chrome programatically"
 license = "MIT"
-homepage = "https://github.com/atroche/rust-headless-chrome"
-repository = "https://github.com/atroche/rust-headless-chrome"
+homepage = "https://github.com/masc-it/rust-headless-chrome"
+repository = "https://github.com/masc-it/rust-headless-chrome"
 readme = "README.md"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headless_chrome_fork"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Alistair Roche <alistair@sunburnt.country>"]
 edition = "2018"
 description = "Control Chrome programatically"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ repository = "https://github.com/atroche/rust-headless-chrome"
 readme = "README.md"
 
 [dependencies]
-websocket = { version = "0.23", default_features = false, features = ["sync"] }
+websocket = { version = "0.24", default_features = false, features = ["sync"] }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = '1'
 thiserror = '1'
 log = "0.4"
-rand = "0.7"
+rand = "0.8"
 tempfile = "3"
 base64 = "0.10"
-derive_builder = "0.8"
+derive_builder = "0.11"
 which = "3.0"
 ureq = { version = "0.11", optional = true }
 directories = { version = "2.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Headless Chrome
 
 [![Build Status](https://travis-ci.com/atroche/rust-headless-chrome.svg?branch=master)](https://travis-ci.com/atroche/rust-headless-chrome)
-[![Crate](https://img.shields.io/crates/v/headless_chrome.svg)](https://crates.io/crates/headless_chrome)
+[![Crate](https://img.shields.io/crates/v/headless_chrome.svg)](https://crates.io/crates/headless_chrome_fork)
 [![API](https://docs.rs/headless_chrome/badge.svg)](https://docs.rs/headless_chrome)
 [![Discord channel](https://img.shields.io/discord/557374784233799681.svg?logo=discord)](https://discord.gg/yyGEzcc)
 

--- a/src/browser/fetcher.rs
+++ b/src/browser/fetcher.rs
@@ -12,10 +12,10 @@ use ureq;
 use walkdir::WalkDir;
 use zip;
 
-pub const CUR_REV: &str = "634997";
+pub const CUR_REV: &str = "1000027"; // "634997";
 
 const APP_NAME: &str = "headless-chrome";
-const DEFAULT_HOST: &str = "https://storage.googleapis.com";
+const DEFAULT_HOST: &str = "https://commondatastorage.googleapis.com";
 
 #[cfg(target_os = "linux")]
 const PLATFORM: &str = "linux";
@@ -334,6 +334,16 @@ where
     {
         Ok(format!(
             "{}/chromium-browser-snapshots/Linux_x64/{}/{}.zip",
+            DEFAULT_HOST,
+            revision.as_ref(),
+            archive_name(revision.as_ref())?
+        ))
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "arm"))]
+    {
+        Ok(format!(
+            "{}/chromium-browser-snapshots/Mac_Arm/{}/{}.zip",
             DEFAULT_HOST,
             revision.as_ref(),
             archive_name(revision.as_ref())?

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -183,9 +183,42 @@ impl<'a> LaunchOptions<'a> {
 }
 
 /// These are passed to the Chrome binary by default.
-/// Via https://github.com/GoogleChrome/puppeteer/blob/master/lib/Launcher.js#L38
-pub static DEFAULT_ARGS: [&str; 23] = [
-    "--disable-background-networking",
+/// Via https://github.com/puppeteer/puppeteer/blob/30c6b13eec4cebf4fe4e5ec069169b562750558e/packages/puppeteer-core/src/node/ChromeLauncher.ts#L159
+/// More on chrome args: https://github.com/GoogleChrome/chrome-launcher/blob/main/docs/chrome-flags-for-tools.md
+pub static DEFAULT_ARGS: [&str; 25] = [
+    "--allow-pre-commit-input",
+      //"--disable-background-networking",
+      "--disable-background-timer-throttling",
+      "--disable-backgrounding-occluded-windows",
+      "--disable-breakpad",
+      "--disable-client-side-phishing-detection",
+      "--disable-component-extensions-with-background-pages",
+      "--disable-component-update",
+      "--disable-default-apps",
+      "--disable-dev-shm-usage",
+      "--deny-permission-prompts",
+      //"--disable-extensions",
+      // AcceptCHFrame disabled because of crbug.com/1348106.
+      "--disable-features=Translate,BackForwardCache,AcceptCHFrame,MediaRouter,OptimizationHints",
+      "--disable-hang-monitor",
+      "--disable-ipc-flooding-protection",
+      "--disable-popup-blocking",
+      "--disable-prompt-on-repost",
+      //"--disable-renderer-backgrounding",
+      "--disable-sync",
+      "--enable-automation",
+      // TODO(sadym): remove '--enable-blink-features=IdleDetection' once
+      // IdleDetection is turned on by default.
+      "--enable-blink-features=IdleDetection",
+      "--enable-features=NetworkServiceInProcess2",
+      "--export-tagged-pdf",
+      "--force-color-profile=srgb",
+      "--metrics-recording-only",
+      "--no-first-run",
+      "--password-store=basic",
+      "--use-mock-keychain",
+
+    /* "--disable-background-networking",
     "--enable-features=NetworkService,NetworkServiceInProcess",
     "--disable-background-timer-throttling",
     "--disable-backgrounding-occluded-windows",
@@ -208,7 +241,7 @@ pub static DEFAULT_ARGS: [&str; 23] = [
     "--no-first-run",
     "--enable-automation",
     "--password-store=basic",
-    "--use-mock-keychain",
+    "--use-mock-keychain", */
 ];
 
 impl Process {

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -277,15 +277,20 @@ impl<'a> Element<'a> {
     pub fn click(&self) -> Result<&Self> {
         self.scroll_into_view()?;
         debug!("Clicking element {:?}", &self);
-        let midpoint = self.get_midpoint()?;
-        self.parent.click_point(midpoint)?;
+
+        self.call_js_fn("function() { this.click(); return 1; }", vec![], false)?
+            .value.unwrap();
+
+
+        /* let midpoint = self.get_midpoint()?;
+        self.parent.click_point(midpoint)?; */
         if let Err(_) = self.parent.wait_until_navigated() {
             info!("[CLICK] Page load timeout..");
         }
         
         // MUST reload DOM in case page refreshed..
         self.parent.load_document();
-        
+
         Ok(self)
     }
 

--- a/src/browser/tab/element/mod.rs
+++ b/src/browser/tab/element/mod.rs
@@ -279,6 +279,13 @@ impl<'a> Element<'a> {
         debug!("Clicking element {:?}", &self);
         let midpoint = self.get_midpoint()?;
         self.parent.click_point(midpoint)?;
+        if let Err(_) = self.parent.wait_until_navigated() {
+            info!("[CLICK] Page load timeout..");
+        }
+        
+        // MUST reload DOM in case page refreshed..
+        self.parent.load_document();
+        
         Ok(self)
     }
 

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -346,6 +346,7 @@ impl Transport {
             open.store(false, Ordering::SeqCst);
             waiting_call_registry.cancel_outstanding_method_calls();
             let mut listeners = listeners.lock().unwrap();
+            listeners.clear();
             *listeners = HashMap::new();
             info!("cleared listeners, I think");
         });

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -150,7 +150,7 @@ fn actions_on_tab_wont_hang_after_browser_drops() -> Result<()> {
         let (_, browser, tab) = dumb_server(include_str!("simple.html"));
         std::thread::spawn(move || {
             let mut rng = rand::thread_rng();
-            let millis: u64 = rng.gen_range(0, 5000);
+            let millis: u64 = rng.gen_range(0..5000);
             std::thread::sleep(std::time::Duration::from_millis(millis));
             trace!("dropping browser");
             drop(browser);
@@ -460,9 +460,9 @@ fn find_element_on_tab_by_xpath() -> Result<()> {
     let inner_element_xpath =
         containing_element_xpath.wait_for_xpath(r#"//*[@id="strictly-above"]"#)?;
     dbg!(&inner_element_xpath);
-    let attrs = inner_element_xpath.get_attributes()?.unwrap();
-    let id: Vec<&String> = attrs.iter().filter(|v| v.as_str() == "id").collect();
-    assert_eq!(id[0].as_str(), "strictly-above");
+    let attrs = inner_element_xpath.get_attributes()?;
+    let id = attrs.get("id").unwrap();
+    assert_eq!(id.as_str(), "strictly-above");
 
     Ok(())
 }


### PR DESCRIPTION
I didn't have access to create a PR through my desktop, so describing it like this. 
In browser/tab/element/mod.rs I've added a check around the loop (line 80) : 

`
```
if attrs_vec.len() > 0 {
            for i in (0..attrs_vec.len() - 1).step_by(2) {
                let k = attrs_vec[i].to_string();
                let v = attrs_vec[i+1].to_string();
                attrs.insert(k, v);
            }
        }
````

That will prevent a panic when there are no elements in the vector. (overflow in dev, index out of bounds in release. 