### PR TITLE
Fixed `clippy` lints + `docs.rs` fix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+#[cfg(not(docsrs))]
 use auto_generate_cdp::init;
 
 fn main() {

--- a/examples/local_storage.rs
+++ b/examples/local_storage.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
 
     let item: String = tab.get_storage("translationHash")?;
 
-    println!("{}", item);
+    println!("{item}");
 
     Ok(())
 }

--- a/examples/print_to_pdf.rs
+++ b/examples/print_to_pdf.rs
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
         .navigate_to("https://www.wikipedia.org")?
         .wait_until_navigated()?
         .print_to_pdf(None)?;
-    fs::write("wiki.pdf", &wikidata)?;
+    fs::write("wiki.pdf", wikidata)?;
     println!("PDF successfully created from internet web page.");
 
     // Browse to the file url and render a pdf of the web page.
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
         .navigate_to(&file_path)?
         .wait_until_navigated()?
         .print_to_pdf(pdf_options)?;
-    fs::write("rust.pdf", &local_pdf)?;
+    fs::write("rust.pdf", local_pdf)?;
     println!("PDF successfully created from local web page.");
 
     Ok(())

--- a/examples/query_wikipedia.rs
+++ b/examples/query_wikipedia.rs
@@ -14,7 +14,7 @@ fn query(input: &str) -> Result<()> {
         .click()?;
     tab.type_str(input)?.press_key("Enter")?;
     match tab.wait_for_element("div.shortdescription") {
-        Err(e) => eprintln!("Query failed: {:?}", e),
+        Err(e) => eprintln!("Query failed: {e:?}"),
         Ok(e) => match e.get_description()?.find(|n| n.node_name == "#text") {
             Some(n) => println!("Result for `{}`: {}", &input, n.node_value),
             None => eprintln!("No shortdescription-node found on page"),

--- a/examples/take_screenshot.rs
+++ b/examples/take_screenshot.rs
@@ -17,14 +17,14 @@ fn main() -> Result<()> {
         .navigate_to("https://www.wikipedia.org")?
         .wait_until_navigated()?
         .capture_screenshot(CaptureScreenshotFormatOption::Jpeg, Some(75), None, true)?;
-    fs::write("screenshot.jpg", &jpeg_data)?;
+    fs::write("screenshot.jpg", jpeg_data)?;
 
     // Browse to the WebKit-Page and take a screenshot of the infobox.
     let png_data = tab
         .navigate_to("https://en.wikipedia.org/wiki/WebKit")?
         .wait_for_element("#mw-content-text > div > table.infobox.vevent")?
         .capture_screenshot(CaptureScreenshotFormatOption::Png)?;
-    fs::write("screenshot.png", &png_data)?;
+    fs::write("screenshot.png", png_data)?;
 
     println!("Screenshots successfully created.");
     Ok(())

--- a/src/browser/mod.rs
+++ b/src/browser/mod.rs
@@ -371,7 +371,7 @@ impl Browser {
                                 }
                             }
                             _ => {
-                                let raw_event = format!("{:?}", event);
+                                let raw_event = format!("{event:?}");
                                 trace!(
                                     "Unhandled event: {}",
                                     raw_event.chars().take(50).collect::<String>()

--- a/src/browser/process.rs
+++ b/src/browser/process.rs
@@ -274,10 +274,10 @@ impl Process {
         } else {
             get_available_port().ok_or(ChromeLaunchError::NoAvailablePorts {})?
         };
-        let port_option = format!("--remote-debugging-port={}", debug_port);
+        let port_option = format!("--remote-debugging-port={debug_port}");
 
         let window_size_option = if let Some((width, height)) = launch_options.window_size {
-            format!("--window-size={},{}", width, height)
+            format!("--window-size={width},{height}")
         } else {
             String::new()
         };
@@ -344,7 +344,7 @@ impl Process {
         }
 
         let proxy_server_option = if let Some(proxy_server) = launch_options.proxy_server {
-            format!("--proxy-server={}", proxy_server)
+            format!("--proxy-server={proxy_server}")
         } else {
             String::new()
         };
@@ -543,11 +543,8 @@ mod tests {
         use std::fs::File;
         use std::io::prelude::*;
         let current_pid = std::process::id();
-        let mut current_process_children_file = File::open(format!(
-            "/proc/{}/task/{}/children",
-            current_pid, current_pid
-        ))
-        .unwrap();
+        let mut current_process_children_file =
+            File::open(format!("/proc/{current_pid}/task/{current_pid}/children")).unwrap();
         let mut child_pids = String::new();
         current_process_children_file
             .read_to_string(&mut child_pids)

--- a/src/browser/transport/mod.rs
+++ b/src/browser/transport/mod.rs
@@ -319,7 +319,7 @@ impl Transport {
                                     listeners.lock().unwrap().get(&ListenerId::Browser)
                                 {
                                     if let Err(err) = tx.send(browser_event.clone()) {
-                                        let event_string = format!("{:?}", browser_event);
+                                        let event_string = format!("{browser_event:?}");
                                         warn!(
                                             "Couldn't send browser an event: {:?}\n{:?}",
                                             event_string.chars().take(400).collect::<String>(),

--- a/src/browser/transport/web_socket_connection.rs
+++ b/src/browser/transport/web_socket_connection.rs
@@ -97,10 +97,7 @@ impl WebSocketConnection {
                         tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
                     ) => break,
                     error => {
-                        panic!(
-                            "Unhandled WebSocket error for Chrome #{:?}: {:?}",
-                            process_id, error
-                        );
+                        panic!("Unhandled WebSocket error for Chrome #{process_id:?}: {error:?}");
                     }
                 },
                 Ok(message) => {
@@ -116,7 +113,7 @@ impl WebSocketConnection {
                             );
                         }
                     } else {
-                        panic!("Got a weird message: {:?}", message);
+                        panic!("Got a weird message: {message:?}");
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,9 @@ clippy::cast_sign_loss, // for tab/element/mod.rs:492 & 493
 clippy::cast_lossless, // for tab/element/mod.rs:492 & 493
 clippy::vtable_address_comparisons, // for tab/mod.rs:1415
 clippy::derivable_impls, // for types.rs Default for PrintToPDF because autogen
+clippy::type_complexity, // for transport/web_socket_connection.rs:133
+clippy::manual_let_else, // for transport/web_socket_connection.rs:142
+clippy::should_implement_trait, // for browser/mod.rs:106
 )]
 
 #[macro_use]

--- a/src/testing_utils/server.rs
+++ b/src/testing_utils/server.rs
@@ -103,7 +103,7 @@ pub fn file_server(path: &'static str) -> Server {
             request.url()
         };
 
-        let file_path = format!("{}{}", path, url);
+        let file_path = format!("{path}{url}");
 
         if let Ok(file_contents) = fs::read_to_string(file_path) {
             let content_type = if url.ends_with(".js") {

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -399,7 +399,7 @@ fn reload() -> Result<()> {
         let response = tiny_http::Response::new(
             200.into(),
             vec![tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html"[..]).unwrap()],
-            std::io::Cursor::new(format!(r#"<div id="counter">{}</div>"#, counter)),
+            std::io::Cursor::new(format!(r#"<div id="counter">{counter}</div>"#)),
             None,
             None,
         );


### PR DESCRIPTION
Fixed a few clippy warnings (and bypassed some others).

Also added a `#[cfg(not(docsrs))]` which should help with the docs.rs issues.