### PR TITLE
call get_document() in find_elements_by_xpath

### DIFF
--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -792,9 +792,8 @@ impl Tab {
     }
 
     pub fn find_elements_by_xpath(&self, query: &str) -> Result<Vec<Element<'_>>> {
-        
         self.get_document()?;
-        
+
         self.call_method(DOM::PerformSearch {
             query: query.to_string(),
             include_user_agent_shadow_dom: None,

--- a/src/browser/tab/mod.rs
+++ b/src/browser/tab/mod.rs
@@ -792,6 +792,9 @@ impl Tab {
     }
 
     pub fn find_elements_by_xpath(&self, query: &str) -> Result<Vec<Element<'_>>> {
+        
+        self.get_document()?;
+        
         self.call_method(DOM::PerformSearch {
             query: query.to_string(),
             include_user_agent_shadow_dom: None,


### PR DESCRIPTION
**Problem**
If you run tab.find_elements_by_xpath(..), tab.wait_for_elements_by_xpath() as first commands in your file, they won't work.

**Solution**
Add a call to get_document() in find_elements_by_xpath(..) function, in the same way as find_elements(..) already does.
